### PR TITLE
Fix link types always being set as linksets

### DIFF
--- a/src/views/AdvancedSearchView/__tests__/index.test.js
+++ b/src/views/AdvancedSearchView/__tests__/index.test.js
@@ -89,7 +89,7 @@ describe('AdvancedSearchView', () => {
     expect(getByText('add to selected group')).toBeInTheDocument();
     expect(getByText('add to selected group')).not.toBeDisabled();
     await fireEvent.click(getByText('add to selected group'));
-    expect(getByText('relevance = value (1:1)')).toBeInTheDocument();
+    expect(getByText('relevance IN value (1:1)')).toBeInTheDocument();
   });
 
   test('fires new search correctly', async () => {
@@ -98,6 +98,6 @@ describe('AdvancedSearchView', () => {
     await fireEvent.click(getByText('add to selected group'));
     fireEvent.click(getByText('Search'));
     expect(mockPush).toHaveBeenCalledTimes(1);
-    expect(mockPush).toHaveBeenCalledWith('/data/table?%40class=Statement&complex=eyJ0YXJnZXQiOiJTdGF0ZW1lbnQiLCJmaWx0ZXJzIjpbeyJvcGVyYXRvciI6Ij0iLCJyZWxldmFuY2UiOlsiMToxIl19XX0%253D');
+    expect(mockPush).toHaveBeenCalledWith('/data/table?%40class=Statement&complex=eyJ0YXJnZXQiOiJTdGF0ZW1lbnQiLCJmaWx0ZXJzIjpbeyJvcGVyYXRvciI6IklOIiwicmVsZXZhbmNlIjpbIjE6MSJdfV19');
   });
 });

--- a/src/views/AdvancedSearchView/components/PropertyFilter/index.js
+++ b/src/views/AdvancedSearchView/components/PropertyFilter/index.js
@@ -49,8 +49,9 @@ const constructOperatorOptions = ({ iterable, type, name } = {}, currentVal, sub
       return OPERATORS.filter(op => ['CONTAINSANY', 'CONTAINSALL', '='].includes(op.label));
     }
     return OPERATORS.filter(op => ['CONTAINS'].includes(op.label));
-  } if (type === 'link') {
-    if (currentVal && Array.isArray(currentVal) && currentVal.length > 1) {
+  }
+  if (type === 'link') {
+    if (currentVal && Array.isArray(currentVal) && currentVal.length > 0) {
       return OPERATORS.filter(op => ['IN'].includes(op.label));
     }
     return OPERATORS.filter(op => ['='].includes(op.label));
@@ -159,7 +160,8 @@ const PropertyFilter = ({
           } else {
             newPropertyModel = null;
           }
-        } else if (newPropertyModel.type === 'linkset') {
+        } else if (newPropertyModel.type === 'link') {
+          newPropertyModel.type = 'linkset';
           newPropertyModel.iterable = true;
         }
 

--- a/src/views/AdvancedSearchView/components/PropertyFilter/index.js
+++ b/src/views/AdvancedSearchView/components/PropertyFilter/index.js
@@ -159,8 +159,7 @@ const PropertyFilter = ({
           } else {
             newPropertyModel = null;
           }
-        } else if (newPropertyModel.type === 'link') {
-          newPropertyModel.type = 'linkset';
+        } else if (newPropertyModel.type === 'linkset') {
           newPropertyModel.iterable = true;
         }
 


### PR DESCRIPTION
The relevance field was always being set as type `linkset` due to this code which cause the API query to send a list instead of a single string.