### PR TITLE
Bump version to 4.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgsc-pori/graphkb-client",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgsc-pori/graphkb-client",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "private": true,
   "bugs": {
     "email": "graphkb@bcgsc.ca"


### PR DESCRIPTION
Same PR, just bumps version to 4.2.2, master hadn't been merged back to dev so the last one should have been 4.2.2 not 4.2.1