### PR TITLE
bugfix/KBDEV-1191 displayname on the clinicaltrial entries on graphKB not in the correct letter case

### DIFF
--- a/src/services/api/index.tsx
+++ b/src/services/api/index.tsx
@@ -34,11 +34,9 @@ const MAX_SUGGESTIONS = 50;
  * @param {Object} payload - PATCH payload.
  */
 const patch = (endpoint: string, payload: Record<string, unknown>): Promise<GeneralRecordType> => {
-  // strip out the display name to have it force-regenerate
-  const { displayName, ...changes } = payload;
   const init = {
     method: 'PATCH',
-    body: jc.stringify(changes),
+    body: jc.stringify(payload),
   };
   return request(endpoint, init);
 };


### PR DESCRIPTION
[KBDEV-1191](https://www.bcgsc.ca/jira/browse/KBDEV-1191):
- remove the force-generate of the displayName