### PR TITLE
KBDEV-845 Handle Unsigned License

### DIFF
--- a/src/components/Auth/index.tsx
+++ b/src/components/Auth/index.tsx
@@ -8,7 +8,7 @@ import React, {
   createContext, ReactNode, useContext, useEffect, useLayoutEffect, useMemo,
 } from 'react';
 import { useMutation } from 'react-query';
-import { RouteProps } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import api from '@/services/api';
 
@@ -157,15 +157,23 @@ interface AuthenticatedRouteProps {
   component: React.ComponentType<any>;
   componentProps?: any;
   admin?: boolean;
+  signedLicenseRequired?: boolean;
 }
 
 const AuthenticatedRoute = (props: AuthenticatedRouteProps) => {
   const {
     admin,
+    signedLicenseRequired,
     component: Comp,
     componentProps = {},
   } = props;
   const auth = useAuth();
+  const navigate = useNavigate();
+
+  const routeChange = () => {
+    const path = '/about/terms';
+    navigate(path);
+  };
 
   useLayoutEffect(() => {
     if (!auth.isAuthenticating && !auth.isAuthenticated && !auth.error) {
@@ -200,6 +208,16 @@ const AuthenticatedRoute = (props: AuthenticatedRouteProps) => {
       </Centered>
     );
   }
+
+  if (signedLicenseRequired && !auth.user?.signedLicenseAt) {
+    return (
+      <Centered>
+        <Typography color="error" gutterBottom variant="h2">Forbidden</Typography>
+        <Typography paragraph>User must sign the license agreement before they can access data.</Typography>
+        <Button onClick={routeChange}>Terms of Use and License Agreement</Button>
+      </Centered>
+    );
+  }
   const cp = componentProps || {};
 
   return <Comp {...cp} />;
@@ -207,6 +225,7 @@ const AuthenticatedRoute = (props: AuthenticatedRouteProps) => {
 
 AuthenticatedRoute.defaultProps = {
   admin: false,
+  signedLicenseRequired: false,
   componentProps: {},
 };
 

--- a/src/views/AboutView/components/AboutMain.tsx
+++ b/src/views/AboutView/components/AboutMain.tsx
@@ -8,9 +8,13 @@ import Chart from 'react-google-charts';
 import { useQuery } from 'react-query';
 
 import api from '@/services/api';
+import { useAuth } from '@/components/Auth';
 
 const AboutMain = () => {
   const theme = useTheme();
+  const auth = useAuth();
+  const hasSignedLicense = !!auth.user?.signedLicenseAt;
+
   const guiVersion = process.env.npm_package_version || process.env.REACT_APP_VERSION || '';
 
   const { data: chartData } = useQuery(
@@ -18,6 +22,7 @@ const AboutMain = () => {
     async ({ queryKey: [route] }) => api.get(route),
     {
       staleTime: Infinity,
+      enabled: hasSignedLicense,
       select: (response) => {
         const { Statement: result } = response;
         const data = [['source', 'count']];

--- a/src/views/AboutView/components/AboutMain.tsx
+++ b/src/views/AboutView/components/AboutMain.tsx
@@ -7,8 +7,8 @@ import React from 'react';
 import Chart from 'react-google-charts';
 import { useQuery } from 'react-query';
 
-import api from '@/services/api';
 import { useAuth } from '@/components/Auth';
+import api from '@/services/api';
 
 const AboutMain = () => {
   const theme = useTheme();

--- a/src/views/AboutView/components/AboutUsageTerms.tsx
+++ b/src/views/AboutView/components/AboutUsageTerms.tsx
@@ -21,7 +21,7 @@ const AboutUsageTerms = () => {
   const [hasSigned, setHasSigned] = useState(false);
 
   const { data } = useQuery(
-    ['/license', user.signedLicenseAt],
+    ['/license', user?.signedLicenseAt],
     () => api.get('/license'),
   );
 

--- a/src/views/AboutView/index.scss
+++ b/src/views/AboutView/index.scss
@@ -58,6 +58,14 @@
     display: block;
   }
 
+  .license-agreement-message {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    padding-top: 40px;
+    width: 100%;
+  }
+
   .tabs-content {
     max-height: calc(100% - #{$tab-bar-height});
     overflow-y: scroll;

--- a/src/views/MainView/index.tsx
+++ b/src/views/MainView/index.tsx
@@ -90,9 +90,9 @@ const Main = () => {
               <Route element={<AuthenticatedRoute component={FeedbackView} />} path="/feedback" />
               <Route element={<ErrorView />} path="/error" />
               <Route element={<AuthenticatedRoute component={AboutView} />} path="/about/*" />
-              <Route element={<AuthenticatedRoute component={ActivityView} />} path="/activity" />
-              <Route element={<AuthenticatedRoute component={QuickSearch} />} path="/query" />
-              <Route element={<AuthenticatedRoute component={AdvancedSearchView} />} path="/query-advanced" />
+              <Route element={<AuthenticatedRoute component={ActivityView} signedLicenseRequired />} path="/activity" />
+              <Route element={<AuthenticatedRoute component={QuickSearch} signedLicenseRequired />} path="/query" />
+              <Route element={<AuthenticatedRoute component={AdvancedSearchView} signedLicenseRequired />} path="/query-advanced" />
               {generateAuthenticatedRoutes(['edit'], ['Source', 'source', 'User', 'user', 'UserGroup', 'usergroup'], {
                 component: RecordView,
                 admin: true,
@@ -114,7 +114,7 @@ const Main = () => {
               <Route element={<AuthenticatedRoute component={GraphView} />} path="/data/graph" />
               <Route element={<AuthenticatedRoute admin component={AdminView} />} path="/admin" />
               <Route element={<AuthenticatedRoute component={ImportPubmedView} />} path="/import/pubmed" />
-              <Route element={<AuthenticatedRoute component={UserProfileView} />} path="/user-profile" />
+              <Route element={<AuthenticatedRoute component={UserProfileView} signedLicenseRequired />} path="/user-profile" />
               <Route element={<Navigate to="/query" />} path="/*" />
             </Routes>
           </Suspense>


### PR DESCRIPTION
- KBDEV-845
- Create new authenticated route prop to display view notifying users to agree to terms before they can see data
- Enforce similar rules to specific tabs in the About section
- Update useQuery() hook for AboutMain view to not fetch chart data if the user has not signed license agreements, preventing error 403 while still render other components