### PR TITLE
bugfix/KBDEV-1216 Add New Variant With Protein Position Show Null Amino Acid

### DIFF
--- a/src/components/VariantForm/index.tsx
+++ b/src/components/VariantForm/index.tsx
@@ -153,6 +153,13 @@ const VariantForm = ({
    */
   const handleSubmitAction = useCallback(async (content) => {
     const payload = cleanPayload(content);
+
+    /* KBDEV-1216 Adding refAA to break1Start property when new variant has ProteinPosition coordinate system.
+    Property has the same value as refSeq and should be hidden from users to avoid confusion. */
+    if (payload?.break1Start['@class'] === 'ProteinPosition') {
+      const refAA = payload.refSeq ? payload.refSeq : '';
+      payload.break1Start = { ...payload.break1Start, refAA };
+    }
     const { routeName } = schemaDefn.get(payload);
 
     const actionType = formVariant === FORM_VARIANT.NEW

--- a/src/components/util.tsx
+++ b/src/components/util.tsx
@@ -184,13 +184,6 @@ const cleanPayload = (payload) => {
       }
     }
   });
-
-  /* KBDEV-1216 Adding refAA to break1Start property when new variant has ProteinPosition coordinate system.
-  Property has the same value as refSeq and should be hidden from users to avoid confusion. */
-  if (newPayload?.break1Start['@class'] === 'ProteinPosition') {
-    const refAA = newPayload.refSeq ? newPayload.refSeq : '';
-    newPayload.break1Start = { ...newPayload.break1Start, refAA };
-  }
   return newPayload;
 };
 

--- a/src/components/util.tsx
+++ b/src/components/util.tsx
@@ -184,6 +184,13 @@ const cleanPayload = (payload) => {
       }
     }
   });
+
+  /* KBDEV-1216 Adding refAA to break1Start property when new variant has ProteinPosition coordinate system.
+  Property has the same value as refSeq and should be hidden from users to avoid confusion. */
+  if (newPayload?.break1Start['@class'] === 'ProteinPosition') {
+    const refAA = newPayload.refSeq ? newPayload.refSeq : '';
+    newPayload.break1Start = { ...newPayload.break1Start, refAA };
+  }
   return newPayload;
 };
 


### PR DESCRIPTION
- Add refAA to break1Start for new variant with ProteinPosition coordinate system to avoid gkb parser flagging refSeq as '?'