### PR TITLE
bugfix/KBDEV-1254 New Records of Abstract Classes Unnecessarily Required Admin Permission

### DIFF
--- a/src/components/QueryResultsTable/index.tsx
+++ b/src/components/QueryResultsTable/index.tsx
@@ -77,13 +77,13 @@ const QueryResultsTable = ({
         <AgGridReact
           {...grid.props}
           columnDefs={columnDefs}
-          rowData={data}
           deltaRowDataMode
           enableCellTextSelection
           frameworkComponents={{ JumpToRecord }}
           getRowNodeId={(rowData) => rowData['@rid']}
           pagination
           paginationAutoPageSize
+          rowData={data}
           suppressHorizontalScroll
         />
       </div>

--- a/src/components/QueryResultsTable/index.tsx
+++ b/src/components/QueryResultsTable/index.tsx
@@ -77,7 +77,7 @@ const QueryResultsTable = ({
         <AgGridReact
           {...grid.props}
           columnDefs={columnDefs}
-          data={data}
+          rowData={data}
           deltaRowDataMode
           enableCellTextSelection
           frameworkComponents={{ JumpToRecord }}

--- a/src/views/ActivityView/index.tsx
+++ b/src/views/ActivityView/index.tsx
@@ -133,13 +133,13 @@ const ActivityView = () => {
               sortable: true,
             },
           ]}
-          rowData={recentRecords}
           deltaRowDataMode
           enableCellTextSelection
           frameworkComponents={{ JumpToRecord }}
           getRowNodeId={(data) => data['@rid']}
           pagination
           paginationAutoPageSize
+          rowData={recentRecords}
           suppressHorizontalScroll
         />
       </div>

--- a/src/views/ActivityView/index.tsx
+++ b/src/views/ActivityView/index.tsx
@@ -71,7 +71,7 @@ const ActivityView = () => {
       }),
     ]);
     const result = [...records, ...edges]
-      .sort((rec1, rec2) => (rec2.updatedAt || rec2.createdAt) - (rec1.updatedAt || rec1.createdAt));
+      .sort((rec1: any, rec2: any) => (rec2.updatedAt || rec2.createdAt) - (rec1.updatedAt || rec1.createdAt));
     return result;
   });
 
@@ -133,7 +133,7 @@ const ActivityView = () => {
               sortable: true,
             },
           ]}
-          data={recentRecords}
+          rowData={recentRecords}
           deltaRowDataMode
           enableCellTextSelection
           frameworkComponents={{ JumpToRecord }}

--- a/src/views/MainView/index.tsx
+++ b/src/views/MainView/index.tsx
@@ -107,7 +107,7 @@ const Main = () => {
               })}
               {generateAuthenticatedRoutes(['new'], [...ABSTRACT_CLASSES, ...ABSTRACT_CLASSES.map((m) => m.toLowerCase())], {
                 component: NewRecordSelectView,
-                admin: true,
+                admin: false,
               })}
               <Route element={<AuthenticatedRoute component={NewRecordView} />} path="/new/:modelName" />
               <Route element={<AuthenticatedRoute component={DataView} />} path="/data/table" />


### PR DESCRIPTION
- Fix bug in main view where new records of abstract classes (e.g.: ontology, relationship) required admin permission
- Fix rowData typos for ag grid calls
- Code lint