### PR TITLE
bugfix/KBDEV-1270 Error handling when expanding graph view failed

### DIFF
--- a/src/components/DetailDrawer/RelationshipList/index.tsx
+++ b/src/components/DetailDrawer/RelationshipList/index.tsx
@@ -48,10 +48,12 @@ function RelationshipList(props: RelationshipListProps) {
       {edges.map((edge) => {
         const isOpen = linkOpen === rid(edge);
         let isIn = false;
+
         if (edge.in !== undefined) {
           isIn = edge.in && rid(edge.in) === rid(record);
         }
         const targetNode = isIn ? edge.out : edge.in;
+
         if (targetNode === undefined || rid(targetNode) === rid(record)) {
           return null;
         }

--- a/src/components/DetailDrawer/RelationshipList/index.tsx
+++ b/src/components/DetailDrawer/RelationshipList/index.tsx
@@ -48,13 +48,11 @@ function RelationshipList(props: RelationshipListProps) {
       {edges.map((edge) => {
         const isOpen = linkOpen === rid(edge);
         let isIn = false;
-
         if (edge.in !== undefined) {
           isIn = edge.in && rid(edge.in) === rid(record);
         }
         const targetNode = isIn ? edge.out : edge.in;
-
-        if (rid(targetNode) === rid(record)) {
+        if (targetNode === undefined || rid(targetNode) === rid(record)) {
           return null;
         }
         let preview;

--- a/src/services/schema.tsx
+++ b/src/services/schema.tsx
@@ -97,7 +97,11 @@ function getEdges<ReqFields extends string = string>(node: GeneralRecordType<Req
     const edges: EdgeType[] = [];
     Object.keys(node)
       .filter((key) => key.split('_')[1] && list.includes(key.split('_')[1]))
-      .forEach((key) => edges.push(...node[key]));
+      .forEach((key) => {
+        if (node[key].deletedAt === null) {
+          edges.push(...node[key]);
+        }
+      });
     return edges;
   }
 

--- a/src/services/schema.tsx
+++ b/src/services/schema.tsx
@@ -98,7 +98,7 @@ function getEdges<ReqFields extends string = string>(node: GeneralRecordType<Req
     Object.keys(node)
       .filter((key) => key.split('_')[1] && list.includes(key.split('_')[1]))
       .forEach((key) => {
-        if (node[key].deletedAt === null) {
+        if (node[key].deletedAt === undefined || null) {
           edges.push(...node[key]);
         }
       });


### PR DESCRIPTION
[KBDEV-1270](https://www.bcgsc.ca/jira/browse/KBDEV-1270)
- check for deleted edge to avoid undefined error
- make getEdges not return soft deleted edge