### PR TITLE
Release/v4.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/preset-typescript": "^7.24.1",
         "@babel/runtime": "^7.24.0",
         "@bcgsc-pori/graphkb-parser": "^2.1.0",
-        "@bcgsc-pori/graphkb-schema": "4.0.0",
+        "@bcgsc-pori/graphkb-schema": "~4.1.0",
         "@material-ui/core": "^4.12.4",
         "@material-ui/icons": "^4.11.3",
         "@material-ui/lab": "^4.0.0-alpha.61",
@@ -1964,9 +1964,10 @@
       }
     },
     "node_modules/@bcgsc-pori/graphkb-schema": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@bcgsc-pori/graphkb-schema/-/graphkb-schema-4.0.0.tgz",
-      "integrity": "sha512-RrlUYPY/5PyB/HI854rsG2W2DRRVqfg233zgftIEZlKPDpefizrjOROpoMvb/r4usrGQ2blXvRL8FKlvLEpL7g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@bcgsc-pori/graphkb-schema/-/graphkb-schema-4.1.0.tgz",
+      "integrity": "sha512-xJ7gfkRn6YYrPSJ/Uu42FiEqQWIUlxxY0Z2/Hwj85p450cclPEqqz/d8LOo91ts+TBnK/gsNx4fxBv7AqOx54g==",
+      "license": "GPL-3.0",
       "dependencies": {
         "lodash.omit": "4.5.0",
         "typescript": "^4.5.5",
@@ -1975,7 +1976,7 @@
         "validator": "^13.7.0"
       },
       "peerDependencies": {
-        "@bcgsc-pori/graphkb-parser": "^2.0.0"
+        "@bcgsc-pori/graphkb-parser": "^2.1.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bcgsc-pori/graphkb-client",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcgsc-pori/graphkb-client",
-      "version": "4.4.0",
+      "version": "4.4.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@babel/plugin-transform-class-properties": "^7.23.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgsc-pori/graphkb-client",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "private": true,
   "bugs": {
     "email": "graphkb@bcgsc.ca"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@babel/preset-typescript": "^7.24.1",
     "@babel/runtime": "^7.24.0",
     "@bcgsc-pori/graphkb-parser": "^2.1.0",
-    "@bcgsc-pori/graphkb-schema": "~4.0.0",
+    "@bcgsc-pori/graphkb-schema": "~4.1.0",
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.61",


### PR DESCRIPTION
### Release Notes - Knowledge Base development - Version client v4.4.1

**Tasks**
[[KBDEV-1360](https://www.bcgsc.ca/jira/browse/KBDEV-1360)] - Use schema version 4.1.0. Allows for preclinical warning and evidence levels to be shown in Statement title [[#100](https://github.com/bcgsc/pori_graphkb_client/pull/100)]