### PR TITLE
[KBDEV-1372] details now clickable on Popover

### DIFF
--- a/src/components/DetailChip/index.tsx
+++ b/src/components/DetailChip/index.tsx
@@ -16,7 +16,7 @@ import {
 } from '@material-ui/core';
 import AssignmentOutlinedIcon from '@material-ui/icons/AssignmentOutlined';
 import OpenInNewIcon from '@material-ui/icons/OpenInNew';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 interface DefaultPopupComponentProps {
@@ -135,23 +135,22 @@ function DetailChip(props: DetailChipProps) {
     PopUpProps,
     ...rest
   } = props;
-
   const [anchorEl, setAnchorEl] = useState(null);
 
   /**
    * Closes popover.
    */
-  const handlePopoverClose = () => {
+  const handlePopoverClose = useCallback(() => {
     setAnchorEl(null);
-  };
+  }, []);
 
   /**
    * Opens popover.
    * @param {Event} event - User click event.
    */
-  const handlePopoverOpen = (event) => {
+  const handlePopoverOpen = useCallback((event) => {
     setAnchorEl(event.currentTarget);
-  };
+  }, []);
 
   return (
     <div className="detail-chip" {...rest}>
@@ -159,7 +158,9 @@ function DetailChip(props: DetailChipProps) {
         anchorEl={anchorEl}
         anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
         className="detail-chip__popover detail-popover"
+        onClick={(e) => e.stopPropagation()}
         onClose={handlePopoverClose}
+        onMouseDown={(e) => e.stopPropagation()}
         open={!!anchorEl}
         transformOrigin={{ vertical: 'bottom', horizontal: 'left' }}
       >

--- a/src/components/RecordAutocomplete/index.tsx
+++ b/src/components/RecordAutocomplete/index.tsx
@@ -34,6 +34,9 @@ const valueToString = (record) => {
   if (Array.isArray(record)) {
     return `Array(${record.length})`;
   }
+  if (typeof record === 'object') {
+    return JSON.stringify(record, null, 2);
+  }
   return `${record}`;
 };
 


### PR DESCRIPTION
  - events were propagating through popover into autocomplete, causing locking of selection
  - detailChip for RecordAutoComplete now renders object values as with actual values instead of [obj obj]