### PR TITLE
Update sendPrEmail-test script to be nodejs compliant

### DIFF
--- a/.github/scripts/sendPrEmail-test.js
+++ b/.github/scripts/sendPrEmail-test.js
@@ -1,4 +1,4 @@
-import https from 'https';
+const https = require('https');
 
 const {
   AZURE_TENANT_ID,


### PR DESCRIPTION
node only recognizes `require("https")`