### PR TITLE
Kbdev 1488 no nav on error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,9 +28,6 @@ testem.log
 .DS_Store
 Thumbs.db
 
-*.css
-!src/_theme.css
-/src/index.css
 /jsdoc
 /build
 

--- a/.storybook/preview.css
+++ b/.storybook/preview.css
@@ -1,0 +1,3 @@
+html, body, #storybook-root {
+  height: 100%;
+}

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -17,6 +17,7 @@ import { SnackbarProvider } from 'notistack';
 import { AuthContext, AuthContextState } from '../src/components/Auth';
 import { expect, waitFor } from 'storybook/test';
 import { CircularProgress } from '@mui/material';
+import ErrorView from '../src/views/ErrorView';
 
 function wrapAsResponse<T extends Record<string, any> | any[]>(maybeResponse: T | HttpResponse<T>): HttpResponse<T> {
   if (maybeResponse instanceof Response) {
@@ -148,9 +149,11 @@ export interface ViewPreviewType {
 function View() {
   return (
       <div style={{height: '100%', minWidth: '300px'}}>
+        <ErrorView>
           <Suspense fallback={(<CircularProgress color="secondary" />)}>
             <AppRoutes />
           </Suspense>
+        </ErrorView>
       </div>
   )
 }

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,3 +1,5 @@
+import './preview.css';
+
 import React, { Suspense } from 'react';
 import ThemeProvider from '../src/theme';
 import { initialize, mswLoader, getWorker } from 'msw-storybook-addon'
@@ -44,7 +46,7 @@ export const http = {
         return wrapAsResponse(resolver(info));
       })
     },
-    query: (resolver: (body: QueryBody) => (HttpResponse<Partial<GeneralRecordType>[]> | Partial<GeneralRecordType>[])) => http.gkb.post('/api/query', resolver)
+    query: (resolver: (body: QueryBody) => (HttpResponse<Partial<GeneralRecordType>> | HttpResponse<{ message?: string }> | Partial<GeneralRecordType>[])) => http.gkb.post('/api/query', resolver)
   }
 }
 

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -39,6 +39,11 @@ export const http = {
         return wrapAsResponse(resolver(body, info));
       })
     },
+    delete: (url: `/api/${string}`, resolver: (info: ResponseResolverInfo<any>) => AllowedResponse) => {
+      return httpBase.delete(`${window._env_.API_BASE_URL}${url}`, async (info) => {
+        return wrapAsResponse(resolver(info));
+      })
+    },
     query: (resolver: (body: QueryBody) => (HttpResponse<Partial<GeneralRecordType>[]> | Partial<GeneralRecordType>[])) => http.gkb.post('/api/query', resolver)
   }
 }

--- a/src/components/DetailDrawer/index.tsx
+++ b/src/components/DetailDrawer/index.tsx
@@ -54,6 +54,7 @@ interface DetailDrawerProps {
   /** Ontology to be displayed in drawer. */
   node?: GeneralRecordType;
   onClose?: () => void;
+  error?: ReactNode;
 }
 
 /**
@@ -65,6 +66,7 @@ function DetailDrawer(props: DetailDrawerProps) {
     node,
     onClose,
     isEdge = false,
+    error,
   } = props;
   const auth = useAuth();
 
@@ -249,6 +251,7 @@ function DetailDrawer(props: DetailDrawerProps) {
             <CloseIcon />
           </IconButton>
         </div>
+        {error}
         <Divider />
         {otherProps}
         <ListItem

--- a/src/components/RecordForm/__tests__/index.test.tsx
+++ b/src/components/RecordForm/__tests__/index.test.tsx
@@ -66,7 +66,6 @@ describe('RecordForm', () => {
   });
 
   const onSubmitSpy = vi.fn();
-  const onErrorSpy = vi.fn();
   const onToggleStateSpy = vi.fn();
   const snackbarSpy = vi.fn();
 
@@ -78,7 +77,6 @@ describe('RecordForm', () => {
             <SnackbarProvider onEnter={snackbarSpy}>
               <RecordForm
                 modelName="User"
-                onError={onErrorSpy}
                 onSubmit={onSubmitSpy}
                 onToggleState={onToggleStateSpy}
                 title="blargh monkeys"
@@ -127,7 +125,6 @@ describe('RecordForm', () => {
             <SnackbarProvider onEnter={snackbarSpy}>
               <RecordForm
                 modelName="User"
-                onError={onErrorSpy}
                 onSubmit={onSubmitSpy}
                 onToggleState={onToggleStateSpy}
                 title="blargh monkeys"
@@ -175,7 +172,6 @@ describe('RecordForm', () => {
             <AuthContext.Provider value={auth}>
               <RecordForm
                 modelName="User"
-                onError={onErrorSpy}
                 onSubmit={onSubmitSpy}
                 onToggleState={onToggleStateSpy}
                 title="blargh monkeys"

--- a/src/components/RecordForm/index.tsx
+++ b/src/components/RecordForm/index.tsx
@@ -17,6 +17,7 @@ import RecordFormStateToggle from '@/components/RecordFormStateToggle';
 import { GeneralRecordType } from '@/components/types';
 import { cleanPayload, FORM_VARIANT } from '@/components/util';
 import api from '@/services/api';
+import { ErrorMessage } from '@/services/errors';
 import schema from '@/services/schema';
 
 import { useAuth } from '../Auth';
@@ -31,7 +32,6 @@ interface RecordFormProps {
   title: string;
   /** name of class model to be displayed */
   modelName?: string;
-  onError?: (arg: { error: { name?: string; message?: string }; content: unknown }) => void;
   onSubmit?: (record?: GeneralRecordType) => void;
   onToggleState?: (newState: FORM_VARIANT | 'graph') => void;
   /** values of individual properties of passed class model */
@@ -49,7 +49,6 @@ const RecordForm = ({
   title,
   onToggleState,
   onSubmit,
-  onError,
   variant = FORM_VARIANT.VIEW,
 }: RecordFormProps) => {
   const snackbar = useSnackbar();
@@ -63,7 +62,7 @@ const RecordForm = ({
     formIsDirty, setFormIsDirty, formContent, formErrors, formHasErrors,
   } = form;
 
-  const { mutate: addNewAction, isPending: isAdding } = useMutation({
+  const { mutate: addNewAction, isPending: isAdding, error: errorAdding } = useMutation({
     mutationFn: async (content: GeneralRecordType) => {
       const payload = cleanPayload(content);
       const { routeName } = schemaDefn.get(payload);
@@ -72,11 +71,6 @@ const RecordForm = ({
     onSuccess: (result) => {
       snackbar.enqueueSnackbar(`Sucessfully created the record ${result['@rid']}`, { variant: 'success' });
       onSubmit?.(result);
-    },
-    onError: (err: Error, content) => {
-      console.error(err);
-      snackbar.enqueueSnackbar(`Error (${err.name}) in creating the record`, { variant: 'error' });
-      onError?.({ error: err, content });
     },
   });
 
@@ -101,7 +95,7 @@ const RecordForm = ({
     }
   }, [addNewAction, formContent, formErrors, formHasErrors, modelName, setFormIsDirty, snackbar]);
 
-  const { mutate: deleteAction, isPending: isDeleting } = useMutation({
+  const { mutate: deleteAction, isPending: isDeleting, error: errorDeleting } = useMutation({
     mutationFn: async (content: GeneralRecordType) => {
       const { routeName } = schemaDefn.get(content);
       return api.delete(`${routeName}/${content['@rid']!.replace(/^#/, '')}`);
@@ -109,10 +103,6 @@ const RecordForm = ({
     onSuccess: (_, content) => {
       snackbar.enqueueSnackbar(`Successfully deleted the record ${content['@rid']}`, { variant: 'success' });
       onSubmit?.();
-    },
-    onError: (err: Error, content) => {
-      snackbar.enqueueSnackbar(`Error (${err.name}) in deleting the record (${content['@rid']})`, { variant: 'error' });
-      onError?.({ error: err, content });
     },
   });
 
@@ -128,7 +118,7 @@ const RecordForm = ({
     deleteAction(content);
   }, [deleteAction, formContent, modelName]);
 
-  const { mutate: updateAction, isPending: isUpdating } = useMutation({
+  const { mutate: updateAction, isPending: isUpdating, error: errorUpdating } = useMutation({
     mutationFn: async (content: GeneralRecordType) => {
       const payload = cleanPayload(content);
       const { routeName } = schemaDefn.get(payload);
@@ -137,10 +127,6 @@ const RecordForm = ({
     onSuccess: (result) => {
       snackbar.enqueueSnackbar(`Successfully edited the record ${result['@rid']}`, { variant: 'success' });
       onSubmit?.(result);
-    },
-    onError: (err: Error, content) => {
-      snackbar.enqueueSnackbar(`Error (${err.name}) in editing the record (${content['@rid']})`, { variant: 'error' });
-      onError?.({ error: err, content });
     },
   });
 
@@ -215,6 +201,9 @@ const RecordForm = ({
           )}
         </>
       )}
+      <ErrorMessage error={errorAdding}>An error occurred while creating record.</ErrorMessage>
+      <ErrorMessage error={errorDeleting}>An error occurred while deleting record.</ErrorMessage>
+      <ErrorMessage error={errorUpdating}>An error occurred while updating record.</ErrorMessage>
       <div className="record-form__action-buttons">
         {variant === FORM_VARIANT.EDIT && !formContent.deletedAt
           ? (

--- a/src/components/RecordFormDialog/index.tsx
+++ b/src/components/RecordFormDialog/index.tsx
@@ -29,7 +29,6 @@ const RecordFormDialog = (props: RecordFormDialogProps) => {
     isOpen = false,
     modelName,
     onClose,
-    onError,
     onSubmit,
     title = '',
     variant,
@@ -65,7 +64,6 @@ const RecordFormDialog = (props: RecordFormDialogProps) => {
       <DialogContent>
         <RecordForm
           modelName={modelName}
-          onError={onError}
           onSubmit={onSubmit}
           onToggleState={onToggleState}
           title={title}

--- a/src/components/StatementForm/index.stories.tsx
+++ b/src/components/StatementForm/index.stories.tsx
@@ -14,7 +14,6 @@ const meta = preview.meta({
   decorators: [withSnackbar, withAuth, withRouter],
   args: {
     title: 'blargh monkeys',
-    onError: fn(),
     onSubmit: fn(),
     value: {},
   },

--- a/src/components/StatementForm/index.tsx
+++ b/src/components/StatementForm/index.tsx
@@ -24,6 +24,7 @@ import RecordFormStateToggle from '@/components/RecordFormStateToggle';
 import { GeneralRecordType } from '@/components/types';
 import { cleanPayload, FORM_VARIANT, tuple } from '@/components/util';
 import api from '@/services/api';
+import { ErrorMessage } from '@/services/errors';
 
 import CivicEvidenceLink from './CivicEvidenceLink';
 import ReviewDialog from './ReviewDialog';
@@ -33,7 +34,6 @@ const FIELD_EXCLUSIONS = ['groupRestrictions'];
 interface StatementFormProps {
   /** the title for this form */
   title: string;
-  onError?: (arg: { error: { name?: string; message?: string }; content: unknown }) => void;
   onSubmit?: (record?: GeneralRecordType) => void;
   onToggleState?: (newState: FORM_VARIANT | 'graph') => void;
   /** values of individual properties of passed class model */
@@ -50,7 +50,6 @@ const StatementForm = ({
   title,
   onToggleState,
   onSubmit,
-  onError,
   variant = FORM_VARIANT.VIEW,
 }: StatementFormProps) => {
   const params = useParams();
@@ -109,6 +108,7 @@ const StatementForm = ({
     queryKey: [`/statements/${params.rid}?neighbors=1`],
     queryFn: async ({ queryKey: [route] }) => api.get(route),
     enabled: (isempty(initialValue) && Boolean(params.rid)),
+    throwOnError: true,
   });
 
   const snackbar = useSnackbar();
@@ -208,7 +208,7 @@ const StatementForm = ({
     return updatedContent;
   }, [auth]);
 
-  const { mutate: addNewAction, isPending: isAdding } = useMutation({
+  const { mutate: addNewAction, isPending: isAdding, error: errorAdding } = useMutation({
     mutationFn: async (content: GeneralRecordType) => {
       const payload = cleanPayload(content);
       const { routeName } = schemaDefn.get(payload);
@@ -217,11 +217,6 @@ const StatementForm = ({
     onSuccess: (result) => {
       snackbar.enqueueSnackbar(`Sucessfully created the record ${result['@rid']}`, { variant: 'success' });
       onSubmit?.(result);
-    },
-    onError: (err: Error, content) => {
-      console.error(err);
-      snackbar.enqueueSnackbar(`Error (${err.name}) in creating the record`, { variant: 'error' });
-      onError?.({ error: err, content });
     },
   });
 
@@ -242,7 +237,7 @@ const StatementForm = ({
     }
   }, [addNewAction, formContent, formErrors, formHasErrors, model.name, setFormIsDirty, snackbar, statementReviewCheck]);
 
-  const { mutate: deleteAction, isPending: isDeleting } = useMutation({
+  const { mutate: deleteAction, isPending: isDeleting, error: errorDeleting } = useMutation({
     mutationFn: async (content: GeneralRecordType) => {
       const { routeName } = schemaDefn.get(content);
       return api.delete(`${routeName}/${content['@rid']!.replace(/^#/, '')}`);
@@ -250,10 +245,6 @@ const StatementForm = ({
     onSuccess: (_, content) => {
       snackbar.enqueueSnackbar(`Sucessfully deleted the record ${content['@rid']}`, { variant: 'success' });
       onSubmit?.();
-    },
-    onError: (err: Error, content) => {
-      snackbar.enqueueSnackbar(`Error (${err.name}) in deleting the record (${content['@rid']})`, { variant: 'error' });
-      onError?.({ error: err, content });
     },
   });
 
@@ -265,7 +256,7 @@ const StatementForm = ({
     deleteAction(content);
   }, [deleteAction, formContent, model.name]);
 
-  const { mutate: updateAction, isPending: isUpdating } = useMutation({
+  const { mutate: updateAction, isPending: isUpdating, error: errorUpdating } = useMutation({
     mutationFn: async (content: GeneralRecordType) => {
       const payload = cleanPayload(content);
       const { routeName } = schemaDefn.get(payload);
@@ -274,10 +265,6 @@ const StatementForm = ({
     onSuccess: (result) => {
       snackbar.enqueueSnackbar(`Sucessfully edited the record ${result['@rid']}`, { variant: 'success' });
       onSubmit?.(result);
-    },
-    onError: (err: Error, content) => {
-      snackbar.enqueueSnackbar(`Error (${err.name}) in editing the record (${content['@rid']})`, { variant: 'error' });
-      onError?.({ error: err, content });
     },
   });
 
@@ -381,6 +368,9 @@ const StatementForm = ({
           modelName={model.name}
         />
       </FormContext.Provider>
+      <ErrorMessage error={errorAdding}>An error occurred while creating record.</ErrorMessage>
+      <ErrorMessage error={errorDeleting}>An error occurred while deleting record.</ErrorMessage>
+      <ErrorMessage error={errorUpdating}>An error occurred while updating record.</ErrorMessage>
       <div className="statement-form__action-buttons">
         {variant === FORM_VARIANT.EDIT && !formContent.deletedAt
           ? (

--- a/src/components/VariantForm/SteppedForm/index.tsx
+++ b/src/components/VariantForm/SteppedForm/index.tsx
@@ -30,10 +30,11 @@ interface SteppedFormProps {
   formVariant?: FORM_VARIANT;
   isLoading?: boolean;
   value?: Record<string, unknown>;
+  errors?: ReactNode;
 }
 
 const SteppedForm = ({
-  children, modelName, properties, onSubmit, className = '', value = {}, formVariant = FORM_VARIANT.NEW, onDelete, isLoading = false,
+  children, modelName, properties, onSubmit, className = '', value = {}, formVariant = FORM_VARIANT.NEW, onDelete, isLoading = false, errors,
 }: SteppedFormProps) => {
   const snackbar = useSnackbar();
   const [activeStep, setActiveStep] = useState(0);
@@ -102,6 +103,7 @@ const SteppedForm = ({
             </Step>
           );
         })}
+        {errors}
         <div className="stepped-form__actions">
           {formVariant === FORM_VARIANT.EDIT && (
           <ActionButton

--- a/src/components/VariantForm/__tests__/index.test.tsx
+++ b/src/components/VariantForm/__tests__/index.test.tsx
@@ -27,7 +27,7 @@ describe('NewVariant', () => {
       getByText, getByTestId, queryByText,
     } = render(
       <QueryClientProvider client={api.queryClient}>
-        <NewVariant onError={vi.fn()} onSubmit={vi.fn()} />
+        <NewVariant onSubmit={vi.fn()} />
       </QueryClientProvider>,
     ));
   });

--- a/src/components/VariantForm/index.tsx
+++ b/src/components/VariantForm/index.tsx
@@ -16,6 +16,7 @@ import FieldGroup from '@/components/FormLayout/FieldGroup';
 import RadioSelect from '@/components/RadioSelect';
 import { cleanPayload, FORM_VARIANT, sortAndGroupFields } from '@/components/util';
 import api from '@/services/api';
+import { ErrorMessage } from '@/services/errors';
 
 import { GeneralRecordType } from '../types';
 import BreakpointForm from './BreakpointForm';
@@ -92,8 +93,6 @@ const pickInputType = (record) => {
 };
 
 interface VariantFormProps {
-  /** the handler to be called when the submission throws an error */
-  onError: (arg: { error: { name?: string; message?: string }; content: unknown }) => void;
   /** the handler to be called when the form is submitted */
   onSubmit: (record?: GeneralRecordType | null) => void;
   formVariant?: FORM_VARIANT;
@@ -104,7 +103,7 @@ interface VariantFormProps {
  * Input form for new Variants
  */
 const VariantForm = ({
-  onSubmit, onError, value = {}, formVariant = FORM_VARIANT.NEW,
+  onSubmit, value = {}, formVariant = FORM_VARIANT.NEW,
 }: VariantFormProps) => {
   let defaultCoordinateType;
 
@@ -207,12 +206,6 @@ const VariantForm = ({
       snackbar.enqueueSnackbar(`Sucessfully ${actionType} the record ${result['@rid']}`, { variant: 'success' });
       onSubmit(result);
     },
-    onError: (error: any, content) => {
-      const actionType = formVariant === FORM_VARIANT.NEW ? 'creating' : 'editing';
-      console.error(error);
-      snackbar.enqueueSnackbar(`Error (${error.name}) in ${actionType} the record`, { variant: 'error' });
-      onError({ error, content });
-    },
   });
 
   const deleteMutation = useMutation({
@@ -225,11 +218,6 @@ const VariantForm = ({
       queryClient.invalidateQueries();
       snackbar.enqueueSnackbar(`Sucessfully deleted the record ${result['@rid']}`, { variant: 'success' });
       onSubmit(null);
-    },
-    onError: (error: any, content) => {
-      console.error(error);
-      snackbar.enqueueSnackbar(`Error (${error.name}) in deleting the record`, { variant: 'error' });
-      onError({ error, content });
     },
   });
 
@@ -244,6 +232,12 @@ const VariantForm = ({
   return model && (
     <SteppedForm
       className="new-variant"
+      errors={(
+        <>
+          <ErrorMessage error={submitMutation.error}>An error occurred while creating/editing record.</ErrorMessage>
+          <ErrorMessage error={deleteMutation.error}>An error occurred while deleting record.</ErrorMessage>
+        </>
+      )}
       formVariant={formVariant}
       isLoading={submitMutation.isPending || deleteMutation.isPending}
       modelName={model.name}

--- a/src/components/util.tsx
+++ b/src/components/util.tsx
@@ -1,3 +1,4 @@
+import { useSnackbar } from 'notistack';
 import * as qs from 'qs';
 import { NavigateFunction } from 'react-router';
 
@@ -203,7 +204,7 @@ const cleanPayload = (payload) => {
  * @param {object} navigate navigate of react-router-dom
  * @param {function} onErrorCallback callback function to call if error occurs
  */
-const navigateToGraph = (nodeRIDs, navigate: NavigateFunction, onErrorCallback) => {
+const navigateToGraph = (nodeRIDs: unknown[], navigate: NavigateFunction, snackbar: ReturnType<typeof useSnackbar>) => {
   const savedState: { nodes?: string } = {};
   let encodedState;
 
@@ -215,7 +216,7 @@ const navigateToGraph = (nodeRIDs, navigate: NavigateFunction, onErrorCallback) 
     savedState.nodes = encodedContent;
     encodedState = qs.stringify(savedState);
   } catch (err) {
-    onErrorCallback(err);
+    snackbar.enqueueSnackbar({ message: 'Unable to view graph. An error occurred encoding graph state', variant: 'error' });
   }
 
   navigate({

--- a/src/components/util.tsx
+++ b/src/components/util.tsx
@@ -231,6 +231,7 @@ const getNodeRIDsFromURL = (href) => {
   const URLBeforeNodeEncoding = href.split('nodes')[0];
   const encodedData = href.split(URLBeforeNodeEncoding)[1];
   const { nodes } = qs.parse(encodedData.replace(/^\?/, ''));
+  if (!nodes) return [];
 
   const decodedContent = decodeURIComponent(nodes);
   const base64decoded = atob(decodedContent);

--- a/src/services/errors.tsx
+++ b/src/services/errors.tsx
@@ -1,3 +1,8 @@
+import { Alert } from '@mui/material';
+import React from 'react';
+
+import util from './util';
+
 class ErrorMixin extends Error {
   content: any;
 
@@ -72,11 +77,66 @@ class APIConnectionFailureError extends ErrorMixin {
   }
 }
 
+interface EmailReportErrorProps {
+  error: Error;
+}
+
+const ReportErrorMessage = (props: EmailReportErrorProps) => {
+  const { error } = props;
+  const { name } = error;
+  const message = util.massageRecordExistsError(error);
+
+  const jiraLink = <a href={window._env_.CONTACT_TICKET_URL} rel="noopener noreferrer" target="_blank">Ticket/Issue</a>;
+
+  const errorDetails = `Error Details (Please include in error reports)
+version: ${process.env.npm_package_version || process.env.REACT_APP_VERSION || ''}
+error name: ${name}
+error text: ${message}`;
+
+  return (
+    <>
+      Report this error in a {jiraLink} ticket or email us at&nbsp;
+      {' '}
+      <a
+        href={`mailto:${window._env_.CONTACT_EMAIL}?subject=${encodeURIComponent(
+          `${name}: ${message}`,
+        )}&body=${encodeURIComponent(errorDetails)}`}
+      >
+        {window._env_.CONTACT_EMAIL}
+      </a>.
+    </>
+  );
+};
+
+interface ErrorMessageProps {
+  error: Error | null;
+  children?: string;
+  hideReportLink?: boolean;
+}
+
+function ErrorMessage({ error, children, hideReportLink }: ErrorMessageProps) {
+  if (!error) return null;
+
+  return (
+    <Alert severity="error">
+      {children} {util.massageRecordExistsError(error)}
+      {!hideReportLink && (
+        <>
+          {' '}
+          <ReportErrorMessage error={error} />
+        </>
+      )}
+    </Alert>
+  );
+}
+
 export {
   AbortError,
   APIConnectionFailureError,
   AuthenticationError,
   AuthorizationError,
   BadRequestError,
+  ErrorMessage,
   RecordExistsError,
+  ReportErrorMessage,
 };

--- a/src/services/util.tsx
+++ b/src/services/util.tsx
@@ -1,9 +1,6 @@
 /**
  * Handles miscellaneous tasks.
  */
-
-import { NavigateFunction } from 'react-router';
-
 import { GeneralRecordType } from '@/components/types';
 import config from '@/static/config';
 
@@ -214,40 +211,6 @@ const positionInit = (x, y, i, n) => {
   return { x: newX, y: newY };
 };
 
-type NavigateParams = {
-  navigate: NavigateFunction;
-  pathname: string;
-  search: string;
-};
-
-type ReferrerLocation = {
-  pathname: string;
-  search: string;
-} | null;
-
-/**
- * navigates to error view and saves previous locaton to history object so that
- * after login, the user is redirected back to the previous page they were on
- *
- * @param {object} error error object containing message and error name
- * @param {object} nav NavigateParams
- * @param {object} referrerLocation location of application before handling error
- */
-const handleErrorSaveLocation = (error, nav: NavigateParams, referrerLocation: ReferrerLocation = null) => {
-  const { name, message } = error;
-  const { pathname, search, navigate } = nav;
-
-  const savedState = {
-    from: {
-      pathname: referrerLocation ? referrerLocation.pathname : pathname,
-      search: referrerLocation ? referrerLocation.search : search,
-    },
-    error: { name, message },
-  };
-
-  navigate('/error', { state: savedState });
-};
-
 /**
  * Formats RecordExistsError to have a better message instead of raw output from console
  * Returns raw output only if targeted regex does not match
@@ -291,7 +254,6 @@ export default {
   antiCamelCase,
   expandEdges,
   getPallette,
-  handleErrorSaveLocation,
   expanded,
   positionInit,
   formatStr,

--- a/src/views/AboutView/components/Matching/index.tsx
+++ b/src/views/AboutView/components/Matching/index.tsx
@@ -177,9 +177,7 @@ const MatchView = () => {
   }, []);
 
   const handleJumpToGraph = useCallback(() => {
-    navigateToGraph(matches.map((m) => m['@rid']), navigate, (err) => {
-      snackbar.enqueueSnackbar(err, { variant: 'error' });
-    });
+    navigateToGraph(matches.map((m) => m['@rid']), navigate, snackbar);
   }, [navigate, matches, snackbar]);
 
   let alertText = '';

--- a/src/views/AboutView/components/Matching/index.tsx
+++ b/src/views/AboutView/components/Matching/index.tsx
@@ -14,7 +14,7 @@ import React, {
   useState,
 } from 'react';
 import { useQuery, useQueryClient } from 'react-query';
-import { useLocation, useNavigate } from 'react-router';
+import { useNavigate } from 'react-router';
 import { useDebounce } from 'use-debounce';
 
 import DetailChip from '@/components/DetailChip';
@@ -23,7 +23,7 @@ import SearchBox from '@/components/SearchBox';
 import { GeneralRecordType } from '@/components/types';
 import { navigateToGraph, tuple } from '@/components/util';
 import api from '@/services/api';
-import util from '@/services/util';
+import { ErrorMessage } from '@/services/errors';
 
 const MATCH_LIMIT = 100;
 
@@ -98,7 +98,6 @@ const ROOT_TERM_MAPPING = {
 const DEBOUNCE_MS = 100;
 
 const MatchView = () => {
-  const { search, pathname } = useLocation();
   const navigate = useNavigate();
   const snackbar = useSnackbar();
   const [text, setText] = useState('');
@@ -147,12 +146,6 @@ const MatchView = () => {
       };
     },
   });
-
-  useEffect(() => {
-    if (error) {
-      util.handleErrorSaveLocation(error, { navigate, search, pathname });
-    }
-  }, [error, navigate, pathname, search]);
 
   useEffect(() => {
     const normalizedTerm = text.toLowerCase().trim();
@@ -220,6 +213,7 @@ const MatchView = () => {
         onChange={handleTextChange}
         value={text}
       />
+      <ErrorMessage error={error} />
       {text && (isLoading
         ? (<CircularProgress />)
         : (

--- a/src/views/AdminView/components/AdminTable/index.tsx
+++ b/src/views/AdminView/components/AdminTable/index.tsx
@@ -54,11 +54,6 @@ const AdminTable = ({ onChange, records = [], variant = 'User' }: AdminTableProp
     setRecordOpen(undefined);
   };
 
-  const handleDialogError = () => {
-    setDialogOpen(false);
-    setRecordOpen(undefined);
-  };
-
   const handleDialogSubmit = useCallback(() => {
     setDialogOpen(false);
     setRecordOpen(undefined);
@@ -133,7 +128,6 @@ const AdminTable = ({ onChange, records = [], variant = 'User' }: AdminTableProp
         isOpen={dialogOpen}
         modelName={variant}
         onClose={handleDialogCancel}
-        onError={handleDialogError}
         onSubmit={handleDialogSubmit}
         value={recordOpen}
         variant={!recordOpen

--- a/src/views/DataView/__snapshots__/index.stories.tsx.snap
+++ b/src/views/DataView/__snapshots__/index.stories.tsx.snap
@@ -3858,49 +3858,1715 @@ exports[`WithDetailsOpenError snapshot 1`] = `
   <div
   >
     <div
-      class="error-wrapper"
+      class="data-view data-view--squished"
     >
-      <h2
-        class="MuiTypography-h2 MuiTypography-root css-XXXX-MuiTypography-root"
+      <div
+        class="data-view__header"
       >
-        BadRequestError
-      </h2>
-      <h3
-        class="MuiTypography-h3 MuiTypography-root css-XXXX-MuiTypography-root"
-      >
-        Bad Request
-      </h3>
-      <p
-        class="MuiTypography-body1 MuiTypography-paragraph MuiTypography-root css-XXXX-MuiTypography-root"
-      >
-        Report this error in a
-        <a
-          href="https://www.bcgsc.ca/jira/projects/KBDEV"
-          rel="noopener noreferrer"
-          target="_blank"
+        <h5
+          class="MuiTypography-h5 MuiTypography-root css-XXXX-MuiTypography-root"
         >
-          Ticket/Issue
-        </a>
-         ticket or email us at 
-        <a
-          href="mailto:graphkb@bcgsc.ca?subject=BadRequestError%3A%20Bad%20Request&body=Error%20Details%20(Please%20include%20in%20error%20reports)%0Aversion%3A%204.4.1%0Aerror%20name%3A%20BadRequestError%0Aerror%20text%3A%20Bad%20Request"
+          Search
+        </h5>
+        <span
+          aria-label="click here to see active filter groups"
+          class=""
+          data-mui-internal-clone-element="true"
         >
-          graphkb@bcgsc.ca
-        </a>
-        .
-      </p>
-      <a
-        data-discover="true"
-        href="/"
-      >
+          <button
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+              data-testid="FilterListIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
+              />
+            </svg>
+          </button>
+        </span>
+        <div />
         <button
-          class="MuiButton-colorPrimary MuiButton-contained MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-root MuiButton-sizeSmall MuiButtonBase-root css-XXXX-MuiButtonBase-root-MuiButton-root"
+          aria-label="click here for table and export options"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root data-view__edit-filters"
+          data-mui-internal-clone-element="true"
           tabindex="0"
           type="button"
         >
-          Home
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-colorAction MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+            data-testid="MoreHorizIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+            />
+          </svg>
         </button>
-      </a>
+      </div>
+      <div
+        class="data-view__content"
+      >
+        <div
+          class="ag-theme-material data-table"
+          role="presentation"
+        >
+          <div
+            class="ag-theme-batchEditStyle-3 ag-theme-buttonStyle-4 ag-theme-checkboxStyle-5 ag-theme-columnDropStyle-9 ag-theme-iconSet-6 ag-theme-inputStyle-8 ag-theme-params-1 ag-theme-styleMaterial-10 ag-theme-tabStyle-7"
+          >
+            <div
+              class="ag-measurement-container"
+            >
+              <div
+              />
+              <div
+              />
+              <div
+              />
+              <div
+                class="ag-measurement-element-border"
+              />
+              <div
+                class="ag-measurement-element-border"
+              />
+              <div
+                class="ag-measurement-element-border"
+              />
+            </div>
+            <div
+              class="ag-layout-normal ag-ltr ag-root-wrapper"
+              grid-id="5"
+              role="presentation"
+            >
+              <div
+                class="ag-focus-managed ag-layout-normal ag-root-wrapper-body"
+                role="presentation"
+              >
+                <div
+                  class="ag-tab-guard ag-tab-guard-top"
+                  role="presentation"
+                />
+                <div
+                  aria-colcount="33"
+                  aria-rowcount="4"
+                  class="ag-body-vertical-content-no-gap ag-layout-normal ag-root ag-unselectable"
+                  role="grid"
+                >
+                  <div
+                    class="ag-header ag-header-allow-overflow ag-pivot-off"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-header"
+                      role="rowgroup"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-group"
+                        role="row"
+                        tabindex="0"
+                      />
+                    </div>
+                    <div
+                      class="ag-header-viewport"
+                      role="rowgroup"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="ag-header-container"
+                        role="presentation"
+                      >
+                        <div
+                          aria-rowindex="1"
+                          class="ag-header-row ag-header-row-group"
+                          role="row"
+                          tabindex="0"
+                        >
+                          <div
+                            aria-colindex="22"
+                            aria-colspan="3"
+                            aria-expanded="false"
+                            class="ag-header-group-cell ag-header-group-cell-with-group"
+                            col-id="source_0"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              class="ag-header-cell-comp-wrapper ag-header-cell-comp-wrapper-limited-height"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-header-group-cell-label"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-header-group-text"
+                                  data-ref="agLabel"
+                                  role="presentation"
+                                >
+                                  Source
+                                </span>
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-expand-icon ag-header-expand-icon-expanded ag-header-icon ag-hidden"
+                                  data-ref="agOpened"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-expanded"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                <span
+                                  aria-hidden="false"
+                                  class="ag-header-expand-icon ag-header-expand-icon-collapsed ag-header-icon"
+                                  data-ref="agClosed"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-contracted"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                            />
+                          </div>
+                        </div>
+                        <div
+                          aria-rowindex="2"
+                          class="ag-header-row ag-header-row-column"
+                          role="row"
+                          tabindex="0"
+                        >
+                          <div
+                            aria-colindex="1"
+                            class="ag-column-first ag-focus-managed ag-header-cell ag-header-span-height ag-header-span-total"
+                            col-id="preview"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Preview
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="21"
+                            aria-sort="none"
+                            class="ag-focus-managed ag-header-cell ag-header-cell-sortable ag-header-span-height ag-header-span-total"
+                            col-id="name"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Name
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-asc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-desc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-aasc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-adesc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="22"
+                            aria-sort="none"
+                            class="ag-focus-managed ag-header-cell ag-header-cell-sortable"
+                            col-id="source.displayName"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Display Name
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-asc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-desc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-aasc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-adesc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="25"
+                            aria-sort="none"
+                            class="ag-focus-managed ag-header-cell ag-header-cell-sortable ag-header-span-height ag-header-span-total"
+                            col-id="sourceId"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Source Id
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-asc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-desc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-aasc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-adesc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="26"
+                            aria-sort="none"
+                            class="ag-focus-managed ag-header-cell ag-header-cell-sortable ag-header-span-height ag-header-span-total"
+                            col-id="sourceIdVersion"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Source Id Version
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-asc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-desc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-aasc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-adesc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="33"
+                            class="ag-column-last ag-focus-managed ag-header-cell ag-header-span-height ag-header-span-total"
+                            col-id="SubClassOf"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Sub Class Of
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-header"
+                      role="rowgroup"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-group"
+                        role="row"
+                        tabindex="0"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="ag-floating-top ag-selectable"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-floating-top"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-floating-top-viewport ag-viewport"
+                      role="rowgroup"
+                    >
+                      <div
+                        class="ag-floating-top-container"
+                        role="presentation"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-floating-top"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-floating-top-full-width-container"
+                      role="rowgroup"
+                    />
+                  </div>
+                  <div
+                    class="ag-body ag-layout-normal"
+                    role="presentation"
+                  >
+                    <div
+                      class="ag-body-viewport ag-has-focus ag-layout-normal ag-row-no-animation ag-selectable"
+                      role="presentation"
+                    >
+                      <div
+                        aria-hidden="true"
+                        class="ag-hidden ag-pinned-left-cols-container"
+                        role="rowgroup"
+                      />
+                      <div
+                        class="ag-center-cols-viewport ag-viewport"
+                        role="rowgroup"
+                      >
+                        <div
+                          class="ag-center-cols-container"
+                          role="presentation"
+                        >
+                          <div
+                            aria-rowindex="3"
+                            aria-selected="true"
+                            class="ag-row ag-row-even ag-row-first ag-row-focus ag-row-hover ag-row-level-0 ag-row-position-absolute ag-row-selected"
+                            role="row"
+                            row-id="0"
+                            row-index="0"
+                            tabindex="0"
+                          >
+                            <div
+                              aria-colindex="1"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing ag-column-first"
+                              col-id="preview"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-preview-XXXX"
+                                  role="presentation"
+                                >
+                                  immunotherapy
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="21"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="name"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-name-XXXX"
+                                  role="presentation"
+                                >
+                                  immunotherapy
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="22"
+                              class="ag-cell ag-cell-focus ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="source.displayName"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-source.displayName-XXXX"
+                                  role="presentation"
+                                >
+                                  source 1234
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="25"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="sourceId"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-sourceId-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="26"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="sourceIdVersion"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-sourceIdVersion-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="33"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing ag-column-last"
+                              col-id="SubClassOf"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-SubClassOf-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-rowindex="4"
+                            aria-selected="false"
+                            class="ag-row ag-row-last ag-row-level-0 ag-row-no-focus ag-row-odd ag-row-position-absolute"
+                            role="row"
+                            row-id="1"
+                            row-index="1"
+                            tabindex="0"
+                          >
+                            <div
+                              aria-colindex="1"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing ag-column-first"
+                              col-id="preview"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-preview-XXXX"
+                                  role="presentation"
+                                >
+                                  immunological therapy
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="21"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="name"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-name-XXXX"
+                                  role="presentation"
+                                >
+                                  immunological therapy
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="22"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="source.displayName"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-source.displayName-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="25"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="sourceId"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-sourceId-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="26"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="sourceIdVersion"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-sourceIdVersion-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="33"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing ag-column-last"
+                              col-id="SubClassOf"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-SubClassOf-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden="true"
+                        class="ag-hidden ag-pinned-right-cols-container"
+                        role="rowgroup"
+                      />
+                      <div
+                        class="ag-full-width-container"
+                        role="rowgroup"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-body-vertical-scroll ag-scrollbar-invisible"
+                    >
+                      <div
+                        class="ag-body-vertical-scroll-viewport"
+                        data-ref="eViewport"
+                      >
+                        <div
+                          class="ag-body-vertical-scroll-container"
+                          data-ref="eContainer"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="ag-selectable ag-sticky-top"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-sticky-top"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-sticky-top-viewport ag-viewport"
+                      role="rowgroup"
+                    >
+                      <div
+                        class="ag-sticky-top-container"
+                        role="presentation"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-sticky-top"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-sticky-top-full-width-container"
+                      role="rowgroup"
+                    />
+                  </div>
+                  <div
+                    class="ag-selectable ag-sticky-bottom"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-sticky-bottom"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-sticky-bottom-viewport ag-viewport"
+                      role="rowgroup"
+                    >
+                      <div
+                        class="ag-sticky-bottom-container"
+                        role="presentation"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-sticky-bottom"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-sticky-bottom-full-width-container"
+                      role="rowgroup"
+                    />
+                  </div>
+                  <div
+                    class="ag-floating-bottom ag-selectable"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-floating-bottom"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-floating-bottom-viewport ag-viewport"
+                      role="rowgroup"
+                    >
+                      <div
+                        class="ag-floating-bottom-container"
+                        role="presentation"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-floating-bottom"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-floating-bottom-full-width-container"
+                      role="rowgroup"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="ag-body-horizontal-scroll ag-scrollbar-invisible"
+                  >
+                    <div
+                      class="ag-horizontal-left-spacer ag-scroller-corner"
+                      data-ref="eLeftSpacer"
+                    />
+                    <div
+                      class="ag-body-horizontal-scroll-viewport"
+                      data-ref="eViewport"
+                    >
+                      <div
+                        class="ag-body-horizontal-scroll-container"
+                        data-ref="eContainer"
+                      />
+                    </div>
+                    <div
+                      class="ag-horizontal-right-spacer ag-scroller-corner"
+                      data-ref="eRightSpacer"
+                    />
+                  </div>
+                  <div
+                    class="ag-hidden ag-overlay"
+                    role="presentation"
+                  >
+                    <div
+                      class="ag-overlay-panel"
+                      role="presentation"
+                    >
+                      <div
+                        class="ag-layout-normal ag-overlay-wrapper"
+                        data-ref="eOverlayWrapper"
+                        role="presentation"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="ag-tab-guard ag-tab-guard-bottom"
+                  role="presentation"
+                />
+              </div>
+              <div
+                aria-hidden="true"
+                class="ag-focus-managed ag-hidden ag-paging-panel ag-unselectable"
+                id="ag-XXXX"
+              >
+                <div
+                  class="ag-tab-guard ag-tab-guard-top"
+                  role="presentation"
+                  tabindex="0"
+                />
+                <span
+                  class="ag-paging-page-size"
+                  data-ref="pageSizeComp"
+                />
+                <span
+                  class="ag-paging-row-summary-panel"
+                >
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    data-ref="lbFirstRowOnPage"
+                    id="ag-XXXX-first-row"
+                  />
+                  <span
+                    id="ag-XXXX-to"
+                  >
+                    to
+                  </span>
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    data-ref="lbLastRowOnPage"
+                    id="ag-XXXX-last-row"
+                  />
+                  <span
+                    id="ag-XXXX-of"
+                  >
+                    of
+                  </span>
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    data-ref="lbRecordCount"
+                    id="ag-XXXX-row-count"
+                  />
+                </span>
+                <span
+                  class="ag-paging-page-summary-panel"
+                  role="presentation"
+                >
+                  <div
+                    aria-label="First Page"
+                    class="ag-button ag-paging-button"
+                    data-ref="btFirst"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-first"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  <div
+                    aria-label="Previous Page"
+                    class="ag-button ag-paging-button"
+                    data-ref="btPrevious"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-previous"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  <span
+                    class="ag-paging-description"
+                  >
+                    <span
+                      id="ag-XXXX-start-page"
+                    >
+                      Page
+                    </span>
+                    <span
+                      class="ag-paging-number"
+                      data-ref="lbCurrent"
+                      id="ag-XXXX-start-page-number"
+                    />
+                    <span
+                      id="ag-XXXX-of-page"
+                    >
+                      of
+                    </span>
+                    <span
+                      class="ag-paging-number"
+                      data-ref="lbTotal"
+                      id="ag-XXXX-of-page-number"
+                    />
+                  </span>
+                  <div
+                    aria-label="Next Page"
+                    class="ag-button ag-paging-button"
+                    data-ref="btNext"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-next"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  <div
+                    aria-label="Last Page"
+                    class="ag-button ag-paging-button"
+                    data-ref="btLast"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-last"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                </span>
+                <div
+                  class="ag-tab-guard ag-tab-guard-bottom"
+                  role="presentation"
+                  tabindex="0"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiDrawer-anchorRight MuiDrawer-docked MuiDrawer-root css-XXXX-MuiDrawer-docked"
+        >
+          <div
+            class="MuiDrawer-paper MuiDrawer-paperAnchorDockedRight MuiDrawer-paperAnchorRight MuiPaper-elevation MuiPaper-elevation0 MuiPaper-root css-XXXX-MuiPaper-root-MuiDrawer-paper detail-drawer"
+          >
+            <div
+              class="detail-drawer__content"
+            >
+              <div
+                class="detail-drawer__heading"
+              >
+                <div>
+                  <h2
+                    class="MuiTypography-h2 MuiTypography-root css-XXXX-MuiTypography-root"
+                  >
+                    immunotherapy (#111:111)
+                  </h2>
+                </div>
+                <a
+                  data-discover="true"
+                  href="/view/Therapy/111:111"
+                  target="_blank"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                      data-testid="OpenInNewIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
+                      />
+                    </svg>
+                  </button>
+                </a>
+                <button
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                    data-testid="CloseIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <div
+                class="MuiAlert-colorError MuiAlert-root MuiAlert-standard MuiAlert-standardError MuiPaper-elevation MuiPaper-elevation0 MuiPaper-root MuiPaper-rounded css-XXXX-MuiPaper-root-MuiAlert-root"
+                role="alert"
+              >
+                <div
+                  class="MuiAlert-icon css-XXXX-MuiAlert-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-fontSizeInherit MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                    data-testid="ErrorOutlineIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiAlert-message css-XXXX-MuiAlert-message"
+                >
+                  An error occurred loading the details.
+                  Bad Request
+                  Report this error in a
+                  <a
+                    href="https://www.bcgsc.ca/jira/projects/KBDEV"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    Ticket/Issue
+                  </a>
+                   ticket or email us at 
+                  <a
+                    href="mailto:graphkb@bcgsc.ca?subject=BadRequestError%3A%20Bad%20Request&body=Error%20Details%20(Please%20include%20in%20error%20reports)%0Aversion%3A%204.4.1%0Aerror%20name%3A%20BadRequestError%0Aerror%20text%3A%20Bad%20Request"
+                  >
+                    graphkb@bcgsc.ca
+                  </a>
+                  .
+                </div>
+              </div>
+              <hr
+                class="MuiDivider-fullWidth MuiDivider-root css-XXXX-MuiDivider-root"
+              />
+              <li
+                class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root"
+              >
+                <div
+                  class="MuiListItemText-dense MuiListItemText-root css-XXXX-MuiListItemText-root detail-li-text"
+                >
+                  <span
+                    class="MuiListItemText-primary MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root"
+                  >
+                    <div
+                      class="detail-identifiers"
+                    >
+                      <p
+                        class="MuiTypography-body1 MuiTypography-root css-XXXX-MuiTypography-root"
+                      >
+                        Source
+                      </p>
+                      <p
+                        class="MuiTypography-body1 MuiTypography-root css-XXXX-MuiTypography-root"
+                      >
+                        source 1234
+                      </p>
+                    </div>
+                  </span>
+                </div>
+              </li>
+              <hr
+                class="MuiDivider-fullWidth MuiDivider-root css-XXXX-MuiDivider-root"
+              />
+              <li
+                class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root"
+              >
+                <div
+                  class="MuiListItemText-dense MuiListItemText-root css-XXXX-MuiListItemText-root detail-li-text"
+                >
+                  <span
+                    class="MuiListItemText-primary MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root"
+                  >
+                    <div
+                      class="detail-identifiers"
+                    >
+                      <p
+                        class="MuiTypography-body1 MuiTypography-root css-XXXX-MuiTypography-root"
+                      >
+                        Name
+                      </p>
+                      <p
+                        class="MuiTypography-body1 MuiTypography-root css-XXXX-MuiTypography-root"
+                      >
+                        immunotherapy
+                      </p>
+                    </div>
+                  </span>
+                </div>
+              </li>
+              <hr
+                class="MuiDivider-fullWidth MuiDivider-root css-XXXX-MuiDivider-root"
+              />
+              <li
+                class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root"
+              >
+                <div
+                  class="MuiListItemText-dense MuiListItemText-root css-XXXX-MuiListItemText-root"
+                >
+                  <p
+                    class="MuiTypography-body1 MuiTypography-root css-XXXX-MuiTypography-root"
+                  >
+                    Metadata
+                  </p>
+                </div>
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                  data-testid="ExpandMoreIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                  />
+                </svg>
+              </li>
+              <hr
+                class="MuiDivider-fullWidth MuiDivider-root css-XXXX-MuiDivider-root"
+              />
+              <li
+                class="MuiListSubheader-gutters MuiListSubheader-root MuiListSubheader-sticky css-XXXX-MuiListSubheader-root detail-drawer__relationships-subheader"
+              >
+                Relationships
+              </li>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="data-view__footer"
+      >
+        <div
+          class="footer__selected-records"
+        >
+          <p
+            class="MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root"
+          >
+            1
+             Record
+             Selected
+          </p>
+          <span
+            aria-label="click here for graph view"
+            class=""
+            data-mui-internal-clone-element="true"
+          >
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                data-testid="TimelineIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2"
+                />
+              </svg>
+            </button>
+          </span>
+        </div>
+        <p
+          class="MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root footer__total-rows"
+        >
+          Total Rows:
+          2
+        </p>
+      </div>
     </div>
   </div>
 </div>

--- a/src/views/DataView/__snapshots__/index.stories.tsx.snap
+++ b/src/views/DataView/__snapshots__/index.stories.tsx.snap
@@ -1,0 +1,6718 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`NoRows snapshot 1`] = `
+<div>
+  <div
+  >
+    <div
+      class="data-view"
+    >
+      <div
+        class="data-view__header"
+      >
+        <h5
+          class="MuiTypography-h5 MuiTypography-root css-XXXX-MuiTypography-root"
+        >
+          Search
+        </h5>
+        <span
+          aria-label="click here to see active filter groups"
+          class=""
+          data-mui-internal-clone-element="true"
+        >
+          <button
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+              data-testid="FilterListIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
+              />
+            </svg>
+          </button>
+        </span>
+        <div />
+        <button
+          aria-label="click here for table and export options"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root data-view__edit-filters"
+          data-mui-internal-clone-element="true"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-colorAction MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+            data-testid="MoreHorizIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="data-view__content"
+      >
+        <div
+          class="ag-theme-material data-table"
+          role="presentation"
+        >
+          <div
+            class="ag-theme-batchEditStyle-3 ag-theme-buttonStyle-4 ag-theme-checkboxStyle-5 ag-theme-columnDropStyle-9 ag-theme-iconSet-6 ag-theme-inputStyle-8 ag-theme-params-1 ag-theme-styleMaterial-10 ag-theme-tabStyle-7"
+          >
+            <div
+              class="ag-measurement-container"
+            >
+              <div
+              />
+              <div
+              />
+              <div
+              />
+              <div
+                class="ag-measurement-element-border"
+              />
+              <div
+                class="ag-measurement-element-border"
+              />
+              <div
+                class="ag-measurement-element-border"
+              />
+            </div>
+            <div
+              class="ag-layout-normal ag-ltr ag-root-wrapper"
+              grid-id="1"
+              role="presentation"
+            >
+              <div
+                class="ag-focus-managed ag-layout-normal ag-root-wrapper-body"
+                role="presentation"
+              >
+                <div
+                  class="ag-tab-guard ag-tab-guard-top"
+                  role="presentation"
+                  tabindex="0"
+                />
+                <div
+                  aria-colcount="96"
+                  aria-rowcount="-1"
+                  class="ag-body-vertical-content-no-gap ag-layout-normal ag-root ag-unselectable"
+                  role="grid"
+                >
+                  <div
+                    class="ag-header ag-header-allow-overflow ag-pivot-off"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-header"
+                      role="rowgroup"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-group"
+                        role="row"
+                        tabindex="0"
+                      />
+                    </div>
+                    <div
+                      class="ag-header-viewport"
+                      role="rowgroup"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="ag-header-container"
+                        role="presentation"
+                      >
+                        <div
+                          aria-rowindex="1"
+                          class="ag-header-row ag-header-row-group"
+                          role="row"
+                          tabindex="0"
+                        >
+                          <div
+                            aria-colindex="17"
+                            aria-colspan="3"
+                            class="ag-header-group-cell ag-header-group-cell-with-group"
+                            col-id="Conditions_0"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              class="ag-header-cell-comp-wrapper ag-header-cell-comp-wrapper-limited-height"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-header-group-cell-label"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-header-group-text"
+                                  data-ref="agLabel"
+                                  role="presentation"
+                                >
+                                  Conditions
+                                </span>
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-expand-icon ag-header-expand-icon-expanded ag-header-icon ag-hidden"
+                                  data-ref="agOpened"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-expanded"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-expand-icon ag-header-expand-icon-collapsed ag-header-icon ag-hidden"
+                                  data-ref="agClosed"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-contracted"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                            />
+                          </div>
+                          <div
+                            aria-colindex="69"
+                            aria-colspan="3"
+                            aria-expanded="false"
+                            class="ag-header-group-cell ag-header-group-cell-with-group"
+                            col-id="source_0"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              class="ag-header-cell-comp-wrapper ag-header-cell-comp-wrapper-limited-height"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-header-group-cell-label"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-header-group-text"
+                                  data-ref="agLabel"
+                                  role="presentation"
+                                >
+                                  Source
+                                </span>
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-expand-icon ag-header-expand-icon-expanded ag-header-icon ag-hidden"
+                                  data-ref="agOpened"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-expanded"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                <span
+                                  aria-hidden="false"
+                                  class="ag-header-expand-icon ag-header-expand-icon-collapsed ag-header-icon"
+                                  data-ref="agClosed"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-contracted"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                            />
+                          </div>
+                        </div>
+                        <div
+                          aria-rowindex="2"
+                          class="ag-header-row ag-header-row-column"
+                          role="row"
+                          tabindex="0"
+                        >
+                          <div
+                            aria-colindex="1"
+                            class="ag-column-first ag-focus-managed ag-header-cell ag-header-span-height ag-header-span-total"
+                            col-id="preview"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Preview
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="17"
+                            class="ag-focus-managed ag-header-cell"
+                            col-id="variant"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Variant
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="18"
+                            class="ag-focus-managed ag-header-cell"
+                            col-id="disease"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Disease
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="19"
+                            class="ag-focus-managed ag-header-cell"
+                            col-id="other"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Other
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="35"
+                            class="ag-focus-managed ag-header-cell ag-header-span-height ag-header-span-total"
+                            col-id="evidence"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Evidence
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="36"
+                            class="ag-focus-managed ag-header-cell ag-header-span-height ag-header-span-total"
+                            col-id="evidenceLevel"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Evidence Level
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="49"
+                            aria-sort="none"
+                            class="ag-focus-managed ag-header-cell ag-header-cell-sortable ag-header-span-height ag-header-span-total"
+                            col-id="name"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Name
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-asc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-desc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-aasc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-adesc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="69"
+                            aria-sort="none"
+                            class="ag-focus-managed ag-header-cell ag-header-cell-sortable"
+                            col-id="source.displayName"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Display Name
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-asc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-desc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-aasc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-adesc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="72"
+                            aria-sort="none"
+                            class="ag-focus-managed ag-header-cell ag-header-cell-sortable ag-header-span-height ag-header-span-total"
+                            col-id="sourceId"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Source Id
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-asc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-desc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-aasc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-adesc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="73"
+                            aria-sort="none"
+                            class="ag-focus-managed ag-header-cell ag-header-cell-sortable ag-header-span-height ag-header-span-total"
+                            col-id="sourceIdVersion"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Source Id Version
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-asc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-desc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-aasc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-adesc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="92"
+                            aria-sort="none"
+                            class="ag-focus-managed ag-header-cell ag-header-cell-sortable ag-header-span-height ag-header-span-total"
+                            col-id="version"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Version
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-asc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-desc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-aasc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-adesc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="96"
+                            class="ag-column-last ag-focus-managed ag-header-cell ag-header-span-height ag-header-span-total"
+                            col-id="SubClassOf"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Sub Class Of
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-header"
+                      role="rowgroup"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-group"
+                        role="row"
+                        tabindex="0"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="ag-floating-top ag-selectable"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-floating-top"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-floating-top-viewport ag-viewport"
+                      role="rowgroup"
+                    >
+                      <div
+                        class="ag-floating-top-container"
+                        role="presentation"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-floating-top"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-floating-top-full-width-container"
+                      role="rowgroup"
+                    />
+                  </div>
+                  <div
+                    class="ag-body ag-layout-normal"
+                    role="presentation"
+                  >
+                    <div
+                      class="ag-body-viewport ag-layout-normal ag-row-no-animation ag-selectable"
+                      role="presentation"
+                    >
+                      <div
+                        aria-hidden="true"
+                        class="ag-hidden ag-pinned-left-cols-container"
+                        role="rowgroup"
+                      />
+                      <div
+                        class="ag-center-cols-viewport ag-viewport"
+                        role="rowgroup"
+                      >
+                        <div
+                          class="ag-center-cols-container"
+                          role="presentation"
+                        >
+                          <div
+                            aria-rowindex="3"
+                            aria-selected="false"
+                            class="ag-row ag-row-even ag-row-first ag-row-last ag-row-level-0 ag-row-no-focus ag-row-position-absolute"
+                            role="row"
+                            row-index="0"
+                            tabindex="0"
+                          >
+                            <div
+                              aria-colindex="1"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing ag-column-first"
+                              col-id="preview"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-preview-XXXX"
+                                  role="presentation"
+                                >
+                                  undefined
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="17"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="variant"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-variant-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="18"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="disease"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-disease-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="19"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="other"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-other-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="35"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="evidence"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-evidence-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="36"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="evidenceLevel"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-evidenceLevel-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="49"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="name"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-name-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="69"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="source.displayName"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-source.displayName-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="72"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="sourceId"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-sourceId-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="73"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="sourceIdVersion"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-sourceIdVersion-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="92"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="version"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-version-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="96"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing ag-column-last"
+                              col-id="SubClassOf"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-SubClassOf-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden="true"
+                        class="ag-hidden ag-pinned-right-cols-container"
+                        role="rowgroup"
+                      />
+                      <div
+                        class="ag-full-width-container"
+                        role="rowgroup"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-body-vertical-scroll ag-scrollbar-invisible"
+                    >
+                      <div
+                        class="ag-body-vertical-scroll-viewport"
+                        data-ref="eViewport"
+                      >
+                        <div
+                          class="ag-body-vertical-scroll-container"
+                          data-ref="eContainer"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="ag-selectable ag-sticky-top"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-sticky-top"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-sticky-top-viewport ag-viewport"
+                      role="rowgroup"
+                    >
+                      <div
+                        class="ag-sticky-top-container"
+                        role="presentation"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-sticky-top"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-sticky-top-full-width-container"
+                      role="rowgroup"
+                    />
+                  </div>
+                  <div
+                    class="ag-selectable ag-sticky-bottom"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-sticky-bottom"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-sticky-bottom-viewport ag-viewport"
+                      role="rowgroup"
+                    >
+                      <div
+                        class="ag-sticky-bottom-container"
+                        role="presentation"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-sticky-bottom"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-sticky-bottom-full-width-container"
+                      role="rowgroup"
+                    />
+                  </div>
+                  <div
+                    class="ag-floating-bottom ag-selectable"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-floating-bottom"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-floating-bottom-viewport ag-viewport"
+                      role="rowgroup"
+                    >
+                      <div
+                        class="ag-floating-bottom-container"
+                        role="presentation"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-floating-bottom"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-floating-bottom-full-width-container"
+                      role="rowgroup"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="ag-body-horizontal-scroll ag-scrollbar-invisible"
+                  >
+                    <div
+                      class="ag-horizontal-left-spacer ag-scroller-corner"
+                      data-ref="eLeftSpacer"
+                    />
+                    <div
+                      class="ag-body-horizontal-scroll-viewport"
+                      data-ref="eViewport"
+                    >
+                      <div
+                        class="ag-body-horizontal-scroll-container"
+                        data-ref="eContainer"
+                      />
+                    </div>
+                    <div
+                      class="ag-horizontal-right-spacer ag-scroller-corner"
+                      data-ref="eRightSpacer"
+                    />
+                  </div>
+                  <div
+                    class="ag-hidden ag-overlay"
+                    role="presentation"
+                  >
+                    <div
+                      class="ag-overlay-panel"
+                      role="presentation"
+                    >
+                      <div
+                        class="ag-layout-normal ag-overlay-wrapper"
+                        data-ref="eOverlayWrapper"
+                        role="presentation"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="ag-tab-guard ag-tab-guard-bottom"
+                  role="presentation"
+                  tabindex="0"
+                />
+              </div>
+              <div
+                aria-hidden="true"
+                class="ag-focus-managed ag-hidden ag-paging-panel ag-unselectable"
+                id="ag-XXXX"
+              >
+                <div
+                  class="ag-tab-guard ag-tab-guard-top"
+                  role="presentation"
+                  tabindex="0"
+                />
+                <span
+                  class="ag-paging-page-size"
+                  data-ref="pageSizeComp"
+                />
+                <span
+                  class="ag-paging-row-summary-panel"
+                >
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    data-ref="lbFirstRowOnPage"
+                    id="ag-XXXX-first-row"
+                  />
+                  <span
+                    id="ag-XXXX-to"
+                  >
+                    to
+                  </span>
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    data-ref="lbLastRowOnPage"
+                    id="ag-XXXX-last-row"
+                  />
+                  <span
+                    id="ag-XXXX-of"
+                  >
+                    of
+                  </span>
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    data-ref="lbRecordCount"
+                    id="ag-XXXX-row-count"
+                  />
+                </span>
+                <span
+                  class="ag-paging-page-summary-panel"
+                  role="presentation"
+                >
+                  <div
+                    aria-label="First Page"
+                    class="ag-button ag-paging-button"
+                    data-ref="btFirst"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-first"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  <div
+                    aria-label="Previous Page"
+                    class="ag-button ag-paging-button"
+                    data-ref="btPrevious"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-previous"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  <span
+                    class="ag-paging-description"
+                  >
+                    <span
+                      id="ag-XXXX-start-page"
+                    >
+                      Page
+                    </span>
+                    <span
+                      class="ag-paging-number"
+                      data-ref="lbCurrent"
+                      id="ag-XXXX-start-page-number"
+                    />
+                    <span
+                      id="ag-XXXX-of-page"
+                    >
+                      of
+                    </span>
+                    <span
+                      class="ag-paging-number"
+                      data-ref="lbTotal"
+                      id="ag-XXXX-of-page-number"
+                    />
+                  </span>
+                  <div
+                    aria-label="Next Page"
+                    class="ag-button ag-paging-button"
+                    data-ref="btNext"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-next"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  <div
+                    aria-label="Last Page"
+                    class="ag-button ag-paging-button"
+                    data-ref="btLast"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-last"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                </span>
+                <div
+                  class="ag-tab-guard ag-tab-guard-bottom"
+                  role="presentation"
+                  tabindex="0"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiDrawer-anchorRight MuiDrawer-docked MuiDrawer-root css-XXXX-MuiDrawer-docked"
+        >
+          <div
+            class="MuiDrawer-paper MuiDrawer-paperAnchorDockedRight MuiDrawer-paperAnchorRight MuiPaper-elevation MuiPaper-elevation0 MuiPaper-root css-XXXX-MuiPaper-root-MuiDrawer-paper detail-drawer detail-drawer--closed"
+          />
+        </div>
+      </div>
+      <div
+        class="data-view__footer"
+      >
+        <div
+          class="footer__selected-records"
+        >
+          <p
+            class="MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root"
+          >
+            0
+             Record
+            s
+             Selected
+          </p>
+          <span
+            aria-label="click here for graph view"
+            class=""
+            data-mui-internal-clone-element="true"
+          >
+            <button
+              class="Mui-disabled MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root"
+              disabled=""
+              tabindex="-1"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-colorDisabled MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                data-testid="TimelineIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2"
+                />
+              </svg>
+            </button>
+          </span>
+        </div>
+        <p
+          class="MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root footer__total-rows"
+        >
+          Total Rows:
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`WithDetailsOpen snapshot 1`] = `
+<div>
+  <div
+  >
+    <div
+      class="data-view data-view--squished"
+    >
+      <div
+        class="data-view__header"
+      >
+        <h5
+          class="MuiTypography-h5 MuiTypography-root css-XXXX-MuiTypography-root"
+        >
+          Search
+        </h5>
+        <span
+          aria-label="click here to see active filter groups"
+          class=""
+          data-mui-internal-clone-element="true"
+        >
+          <button
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+              data-testid="FilterListIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
+              />
+            </svg>
+          </button>
+        </span>
+        <div />
+        <button
+          aria-label="click here for table and export options"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root data-view__edit-filters"
+          data-mui-internal-clone-element="true"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-colorAction MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+            data-testid="MoreHorizIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="data-view__content"
+      >
+        <div
+          class="ag-theme-material data-table"
+          role="presentation"
+        >
+          <div
+            class="ag-theme-batchEditStyle-3 ag-theme-buttonStyle-4 ag-theme-checkboxStyle-5 ag-theme-columnDropStyle-9 ag-theme-iconSet-6 ag-theme-inputStyle-8 ag-theme-params-1 ag-theme-styleMaterial-10 ag-theme-tabStyle-7"
+          >
+            <div
+              class="ag-measurement-container"
+            >
+              <div
+              />
+              <div
+              />
+              <div
+              />
+              <div
+                class="ag-measurement-element-border"
+              />
+              <div
+                class="ag-measurement-element-border"
+              />
+              <div
+                class="ag-measurement-element-border"
+              />
+            </div>
+            <div
+              class="ag-layout-normal ag-ltr ag-root-wrapper"
+              grid-id="4"
+              role="presentation"
+            >
+              <div
+                class="ag-focus-managed ag-layout-normal ag-root-wrapper-body"
+                role="presentation"
+              >
+                <div
+                  class="ag-tab-guard ag-tab-guard-top"
+                  role="presentation"
+                />
+                <div
+                  aria-colcount="33"
+                  aria-rowcount="4"
+                  class="ag-body-vertical-content-no-gap ag-layout-normal ag-root ag-unselectable"
+                  role="grid"
+                >
+                  <div
+                    class="ag-header ag-header-allow-overflow ag-pivot-off"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-header"
+                      role="rowgroup"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-group"
+                        role="row"
+                        tabindex="0"
+                      />
+                    </div>
+                    <div
+                      class="ag-header-viewport"
+                      role="rowgroup"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="ag-header-container"
+                        role="presentation"
+                      >
+                        <div
+                          aria-rowindex="1"
+                          class="ag-header-row ag-header-row-group"
+                          role="row"
+                          tabindex="0"
+                        >
+                          <div
+                            aria-colindex="22"
+                            aria-colspan="3"
+                            aria-expanded="false"
+                            class="ag-header-group-cell ag-header-group-cell-with-group"
+                            col-id="source_0"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              class="ag-header-cell-comp-wrapper ag-header-cell-comp-wrapper-limited-height"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-header-group-cell-label"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-header-group-text"
+                                  data-ref="agLabel"
+                                  role="presentation"
+                                >
+                                  Source
+                                </span>
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-expand-icon ag-header-expand-icon-expanded ag-header-icon ag-hidden"
+                                  data-ref="agOpened"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-expanded"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                <span
+                                  aria-hidden="false"
+                                  class="ag-header-expand-icon ag-header-expand-icon-collapsed ag-header-icon"
+                                  data-ref="agClosed"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-contracted"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                            />
+                          </div>
+                        </div>
+                        <div
+                          aria-rowindex="2"
+                          class="ag-header-row ag-header-row-column"
+                          role="row"
+                          tabindex="0"
+                        >
+                          <div
+                            aria-colindex="1"
+                            class="ag-column-first ag-focus-managed ag-header-cell ag-header-span-height ag-header-span-total"
+                            col-id="preview"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Preview
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="21"
+                            aria-sort="none"
+                            class="ag-focus-managed ag-header-cell ag-header-cell-sortable ag-header-span-height ag-header-span-total"
+                            col-id="name"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Name
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-asc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-desc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-aasc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-adesc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="22"
+                            aria-sort="none"
+                            class="ag-focus-managed ag-header-cell ag-header-cell-sortable"
+                            col-id="source.displayName"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Display Name
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-asc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-desc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-aasc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-adesc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="25"
+                            aria-sort="none"
+                            class="ag-focus-managed ag-header-cell ag-header-cell-sortable ag-header-span-height ag-header-span-total"
+                            col-id="sourceId"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Source Id
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-asc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-desc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-aasc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-adesc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="26"
+                            aria-sort="none"
+                            class="ag-focus-managed ag-header-cell ag-header-cell-sortable ag-header-span-height ag-header-span-total"
+                            col-id="sourceIdVersion"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Source Id Version
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-asc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-desc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-aasc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-adesc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="33"
+                            class="ag-column-last ag-focus-managed ag-header-cell ag-header-span-height ag-header-span-total"
+                            col-id="SubClassOf"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Sub Class Of
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-header"
+                      role="rowgroup"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-group"
+                        role="row"
+                        tabindex="0"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="ag-floating-top ag-selectable"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-floating-top"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-floating-top-viewport ag-viewport"
+                      role="rowgroup"
+                    >
+                      <div
+                        class="ag-floating-top-container"
+                        role="presentation"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-floating-top"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-floating-top-full-width-container"
+                      role="rowgroup"
+                    />
+                  </div>
+                  <div
+                    class="ag-body ag-layout-normal"
+                    role="presentation"
+                  >
+                    <div
+                      class="ag-body-viewport ag-has-focus ag-layout-normal ag-row-no-animation ag-selectable"
+                      role="presentation"
+                    >
+                      <div
+                        aria-hidden="true"
+                        class="ag-hidden ag-pinned-left-cols-container"
+                        role="rowgroup"
+                      />
+                      <div
+                        class="ag-center-cols-viewport ag-viewport"
+                        role="rowgroup"
+                      >
+                        <div
+                          class="ag-center-cols-container"
+                          role="presentation"
+                        >
+                          <div
+                            aria-rowindex="3"
+                            aria-selected="true"
+                            class="ag-row ag-row-even ag-row-first ag-row-focus ag-row-hover ag-row-level-0 ag-row-position-absolute ag-row-selected"
+                            role="row"
+                            row-id="0"
+                            row-index="0"
+                            tabindex="0"
+                          >
+                            <div
+                              aria-colindex="1"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing ag-column-first"
+                              col-id="preview"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-preview-XXXX"
+                                  role="presentation"
+                                >
+                                  immunotherapy
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="21"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="name"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-name-XXXX"
+                                  role="presentation"
+                                >
+                                  immunotherapy
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="22"
+                              class="ag-cell ag-cell-focus ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="source.displayName"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-source.displayName-XXXX"
+                                  role="presentation"
+                                >
+                                  source 1234
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="25"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="sourceId"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-sourceId-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="26"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="sourceIdVersion"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-sourceIdVersion-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="33"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing ag-column-last"
+                              col-id="SubClassOf"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-SubClassOf-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-rowindex="4"
+                            aria-selected="false"
+                            class="ag-row ag-row-last ag-row-level-0 ag-row-no-focus ag-row-odd ag-row-position-absolute"
+                            role="row"
+                            row-id="1"
+                            row-index="1"
+                            tabindex="0"
+                          >
+                            <div
+                              aria-colindex="1"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing ag-column-first"
+                              col-id="preview"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-preview-XXXX"
+                                  role="presentation"
+                                >
+                                  immunological therapy
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="21"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="name"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-name-XXXX"
+                                  role="presentation"
+                                >
+                                  immunological therapy
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="22"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="source.displayName"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-source.displayName-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="25"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="sourceId"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-sourceId-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="26"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="sourceIdVersion"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-sourceIdVersion-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="33"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing ag-column-last"
+                              col-id="SubClassOf"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-SubClassOf-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden="true"
+                        class="ag-hidden ag-pinned-right-cols-container"
+                        role="rowgroup"
+                      />
+                      <div
+                        class="ag-full-width-container"
+                        role="rowgroup"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-body-vertical-scroll ag-scrollbar-invisible"
+                    >
+                      <div
+                        class="ag-body-vertical-scroll-viewport"
+                        data-ref="eViewport"
+                      >
+                        <div
+                          class="ag-body-vertical-scroll-container"
+                          data-ref="eContainer"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="ag-selectable ag-sticky-top"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-sticky-top"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-sticky-top-viewport ag-viewport"
+                      role="rowgroup"
+                    >
+                      <div
+                        class="ag-sticky-top-container"
+                        role="presentation"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-sticky-top"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-sticky-top-full-width-container"
+                      role="rowgroup"
+                    />
+                  </div>
+                  <div
+                    class="ag-selectable ag-sticky-bottom"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-sticky-bottom"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-sticky-bottom-viewport ag-viewport"
+                      role="rowgroup"
+                    >
+                      <div
+                        class="ag-sticky-bottom-container"
+                        role="presentation"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-sticky-bottom"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-sticky-bottom-full-width-container"
+                      role="rowgroup"
+                    />
+                  </div>
+                  <div
+                    class="ag-floating-bottom ag-selectable"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-floating-bottom"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-floating-bottom-viewport ag-viewport"
+                      role="rowgroup"
+                    >
+                      <div
+                        class="ag-floating-bottom-container"
+                        role="presentation"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-floating-bottom"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-floating-bottom-full-width-container"
+                      role="rowgroup"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="ag-body-horizontal-scroll ag-scrollbar-invisible"
+                  >
+                    <div
+                      class="ag-horizontal-left-spacer ag-scroller-corner"
+                      data-ref="eLeftSpacer"
+                    />
+                    <div
+                      class="ag-body-horizontal-scroll-viewport"
+                      data-ref="eViewport"
+                    >
+                      <div
+                        class="ag-body-horizontal-scroll-container"
+                        data-ref="eContainer"
+                      />
+                    </div>
+                    <div
+                      class="ag-horizontal-right-spacer ag-scroller-corner"
+                      data-ref="eRightSpacer"
+                    />
+                  </div>
+                  <div
+                    class="ag-hidden ag-overlay"
+                    role="presentation"
+                  >
+                    <div
+                      class="ag-overlay-panel"
+                      role="presentation"
+                    >
+                      <div
+                        class="ag-layout-normal ag-overlay-wrapper"
+                        data-ref="eOverlayWrapper"
+                        role="presentation"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="ag-tab-guard ag-tab-guard-bottom"
+                  role="presentation"
+                />
+              </div>
+              <div
+                aria-hidden="true"
+                class="ag-focus-managed ag-hidden ag-paging-panel ag-unselectable"
+                id="ag-XXXX"
+              >
+                <div
+                  class="ag-tab-guard ag-tab-guard-top"
+                  role="presentation"
+                  tabindex="0"
+                />
+                <span
+                  class="ag-paging-page-size"
+                  data-ref="pageSizeComp"
+                />
+                <span
+                  class="ag-paging-row-summary-panel"
+                >
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    data-ref="lbFirstRowOnPage"
+                    id="ag-XXXX-first-row"
+                  />
+                  <span
+                    id="ag-XXXX-to"
+                  >
+                    to
+                  </span>
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    data-ref="lbLastRowOnPage"
+                    id="ag-XXXX-last-row"
+                  />
+                  <span
+                    id="ag-XXXX-of"
+                  >
+                    of
+                  </span>
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    data-ref="lbRecordCount"
+                    id="ag-XXXX-row-count"
+                  />
+                </span>
+                <span
+                  class="ag-paging-page-summary-panel"
+                  role="presentation"
+                >
+                  <div
+                    aria-label="First Page"
+                    class="ag-button ag-paging-button"
+                    data-ref="btFirst"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-first"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  <div
+                    aria-label="Previous Page"
+                    class="ag-button ag-paging-button"
+                    data-ref="btPrevious"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-previous"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  <span
+                    class="ag-paging-description"
+                  >
+                    <span
+                      id="ag-XXXX-start-page"
+                    >
+                      Page
+                    </span>
+                    <span
+                      class="ag-paging-number"
+                      data-ref="lbCurrent"
+                      id="ag-XXXX-start-page-number"
+                    />
+                    <span
+                      id="ag-XXXX-of-page"
+                    >
+                      of
+                    </span>
+                    <span
+                      class="ag-paging-number"
+                      data-ref="lbTotal"
+                      id="ag-XXXX-of-page-number"
+                    />
+                  </span>
+                  <div
+                    aria-label="Next Page"
+                    class="ag-button ag-paging-button"
+                    data-ref="btNext"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-next"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  <div
+                    aria-label="Last Page"
+                    class="ag-button ag-paging-button"
+                    data-ref="btLast"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-last"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                </span>
+                <div
+                  class="ag-tab-guard ag-tab-guard-bottom"
+                  role="presentation"
+                  tabindex="0"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiDrawer-anchorRight MuiDrawer-docked MuiDrawer-root css-XXXX-MuiDrawer-docked"
+        >
+          <div
+            class="MuiDrawer-paper MuiDrawer-paperAnchorDockedRight MuiDrawer-paperAnchorRight MuiPaper-elevation MuiPaper-elevation0 MuiPaper-root css-XXXX-MuiPaper-root-MuiDrawer-paper detail-drawer"
+          >
+            <div
+              class="detail-drawer__content"
+            >
+              <div
+                class="detail-drawer__heading"
+              >
+                <div>
+                  <h2
+                    class="MuiTypography-h2 MuiTypography-root css-XXXX-MuiTypography-root"
+                  >
+                    immunotherapy (#111:111)
+                  </h2>
+                </div>
+                <a
+                  data-discover="true"
+                  href="/view/Therapy/111:111"
+                  target="_blank"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                      data-testid="OpenInNewIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
+                      />
+                    </svg>
+                  </button>
+                </a>
+                <button
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                    data-testid="CloseIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <hr
+                class="MuiDivider-fullWidth MuiDivider-root css-XXXX-MuiDivider-root"
+              />
+              <li
+                class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root"
+              >
+                <div
+                  class="MuiListItemText-dense MuiListItemText-root css-XXXX-MuiListItemText-root detail-li-text"
+                >
+                  <span
+                    class="MuiListItemText-primary MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root"
+                  >
+                    <div
+                      class="detail-identifiers"
+                    >
+                      <p
+                        class="MuiTypography-body1 MuiTypography-root css-XXXX-MuiTypography-root"
+                      >
+                        Source
+                      </p>
+                      <p
+                        class="MuiTypography-body1 MuiTypography-root css-XXXX-MuiTypography-root"
+                      >
+                        source 1234
+                      </p>
+                    </div>
+                  </span>
+                </div>
+              </li>
+              <hr
+                class="MuiDivider-fullWidth MuiDivider-root css-XXXX-MuiDivider-root"
+              />
+              <li
+                class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root"
+              >
+                <div
+                  class="MuiListItemText-dense MuiListItemText-root css-XXXX-MuiListItemText-root detail-li-text"
+                >
+                  <span
+                    class="MuiListItemText-primary MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root"
+                  >
+                    <div
+                      class="detail-identifiers"
+                    >
+                      <p
+                        class="MuiTypography-body1 MuiTypography-root css-XXXX-MuiTypography-root"
+                      >
+                        Name
+                      </p>
+                      <p
+                        class="MuiTypography-body1 MuiTypography-root css-XXXX-MuiTypography-root"
+                      >
+                        immunotherapy
+                      </p>
+                    </div>
+                  </span>
+                </div>
+              </li>
+              <hr
+                class="MuiDivider-fullWidth MuiDivider-root css-XXXX-MuiDivider-root"
+              />
+              <li
+                class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root"
+              >
+                <div
+                  class="MuiListItemText-dense MuiListItemText-root css-XXXX-MuiListItemText-root"
+                >
+                  <p
+                    class="MuiTypography-body1 MuiTypography-root css-XXXX-MuiTypography-root"
+                  >
+                    Metadata
+                  </p>
+                </div>
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                  data-testid="ExpandMoreIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                  />
+                </svg>
+              </li>
+              <hr
+                class="MuiDivider-fullWidth MuiDivider-root css-XXXX-MuiDivider-root"
+              />
+              <li
+                class="MuiListSubheader-gutters MuiListSubheader-root MuiListSubheader-sticky css-XXXX-MuiListSubheader-root detail-drawer__relationships-subheader"
+              >
+                Relationships
+              </li>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="data-view__footer"
+      >
+        <div
+          class="footer__selected-records"
+        >
+          <p
+            class="MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root"
+          >
+            1
+             Record
+             Selected
+          </p>
+          <span
+            aria-label="click here for graph view"
+            class=""
+            data-mui-internal-clone-element="true"
+          >
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-colorSecondary MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                data-testid="TimelineIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2"
+                />
+              </svg>
+            </button>
+          </span>
+        </div>
+        <div
+          class="footer__loader"
+        >
+          <span
+            class="MuiCircularProgress-colorPrimary MuiCircularProgress-indeterminate MuiCircularProgress-root css-XXXX-MuiCircularProgress-root"
+            role="progressbar"
+          >
+            <svg
+              class="MuiCircularProgress-svg css-XXXX-MuiCircularProgress-svg"
+              viewBox="22 22 44 44"
+            >
+              <circle
+                class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate css-XXXX-MuiCircularProgress-circle"
+                cx="44"
+                cy="44"
+                fill="none"
+                r="20.2"
+                stroke-width="3.6"
+              />
+            </svg>
+          </span>
+          <p
+            class="MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root"
+          >
+            loading more of 2 rows
+          </p>
+        </div>
+        <p
+          class="MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root footer__total-rows"
+        >
+          Total Rows:
+          2
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`WithDetailsOpenError snapshot 1`] = `
+<div>
+  <div
+  >
+    <div
+      class="error-wrapper"
+    >
+      <h2
+        class="MuiTypography-h2 MuiTypography-root css-XXXX-MuiTypography-root"
+      >
+        BadRequestError
+      </h2>
+      <h3
+        class="MuiTypography-h3 MuiTypography-root css-XXXX-MuiTypography-root"
+      >
+        Bad Request
+      </h3>
+      <p
+        class="MuiTypography-body1 MuiTypography-paragraph MuiTypography-root css-XXXX-MuiTypography-root"
+      >
+        Report this error in a
+        <a
+          href="https://www.bcgsc.ca/jira/projects/KBDEV"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Ticket/Issue
+        </a>
+         ticket or email us at 
+        <a
+          href="mailto:graphkb@bcgsc.ca?subject=BadRequestError%3A%20Bad%20Request&body=Error%20Details%20(Please%20include%20in%20error%20reports)%0Aversion%3A%204.4.1%0Aerror%20name%3A%20BadRequestError%0Aerror%20text%3A%20Bad%20Request"
+        >
+          graphkb@bcgsc.ca
+        </a>
+        .
+      </p>
+      <a
+        data-discover="true"
+        href="/"
+      >
+        <button
+          class="MuiButton-colorPrimary MuiButton-contained MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-root MuiButton-sizeSmall MuiButtonBase-root css-XXXX-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          Home
+        </button>
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`WithError snapshot 1`] = `
+<div>
+  <div
+  >
+    <div
+      class="data-view"
+    >
+      <div
+        class="data-view__header"
+      >
+        <h5
+          class="MuiTypography-h5 MuiTypography-root css-XXXX-MuiTypography-root"
+        >
+          Search
+        </h5>
+        <span
+          aria-label="click here to see active filter groups"
+          class=""
+          data-mui-internal-clone-element="true"
+        >
+          <button
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+              data-testid="FilterListIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
+              />
+            </svg>
+          </button>
+        </span>
+        <div />
+        <button
+          aria-label="click here for table and export options"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root data-view__edit-filters"
+          data-mui-internal-clone-element="true"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-colorAction MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+            data-testid="MoreHorizIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="data-view__content"
+      >
+        <div
+          class="ag-theme-material data-table"
+          role="presentation"
+        >
+          <div
+            class="ag-theme-batchEditStyle-3 ag-theme-buttonStyle-4 ag-theme-checkboxStyle-5 ag-theme-columnDropStyle-9 ag-theme-iconSet-6 ag-theme-inputStyle-8 ag-theme-params-1 ag-theme-styleMaterial-10 ag-theme-tabStyle-7"
+          >
+            <div
+              class="ag-measurement-container"
+            >
+              <div
+              />
+              <div
+              />
+              <div
+              />
+              <div
+                class="ag-measurement-element-border"
+              />
+              <div
+                class="ag-measurement-element-border"
+              />
+              <div
+                class="ag-measurement-element-border"
+              />
+            </div>
+            <div
+              class="ag-layout-normal ag-ltr ag-root-wrapper"
+              grid-id="3"
+              role="presentation"
+            >
+              <div
+                class="ag-focus-managed ag-layout-normal ag-root-wrapper-body"
+                role="presentation"
+              >
+                <div
+                  class="ag-tab-guard ag-tab-guard-top"
+                  role="presentation"
+                  tabindex="0"
+                />
+                <div
+                  aria-colcount="33"
+                  aria-rowcount="-1"
+                  class="ag-body-vertical-content-no-gap ag-layout-normal ag-root ag-unselectable"
+                  role="grid"
+                >
+                  <div
+                    class="ag-header ag-header-allow-overflow ag-pivot-off"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-header"
+                      role="rowgroup"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-group"
+                        role="row"
+                        tabindex="0"
+                      />
+                    </div>
+                    <div
+                      class="ag-header-viewport"
+                      role="rowgroup"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="ag-header-container"
+                        role="presentation"
+                      >
+                        <div
+                          aria-rowindex="1"
+                          class="ag-header-row ag-header-row-group"
+                          role="row"
+                          tabindex="0"
+                        >
+                          <div
+                            aria-colindex="22"
+                            aria-colspan="3"
+                            aria-expanded="false"
+                            class="ag-header-group-cell ag-header-group-cell-with-group"
+                            col-id="source_0"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              class="ag-header-cell-comp-wrapper ag-header-cell-comp-wrapper-limited-height"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-header-group-cell-label"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-header-group-text"
+                                  data-ref="agLabel"
+                                  role="presentation"
+                                >
+                                  Source
+                                </span>
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-expand-icon ag-header-expand-icon-expanded ag-header-icon ag-hidden"
+                                  data-ref="agOpened"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-expanded"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                <span
+                                  aria-hidden="false"
+                                  class="ag-header-expand-icon ag-header-expand-icon-collapsed ag-header-icon"
+                                  data-ref="agClosed"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-contracted"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                            />
+                          </div>
+                        </div>
+                        <div
+                          aria-rowindex="2"
+                          class="ag-header-row ag-header-row-column"
+                          role="row"
+                          tabindex="0"
+                        >
+                          <div
+                            aria-colindex="1"
+                            class="ag-column-first ag-focus-managed ag-header-cell ag-header-span-height ag-header-span-total"
+                            col-id="preview"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Preview
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="21"
+                            aria-sort="none"
+                            class="ag-focus-managed ag-header-cell ag-header-cell-sortable ag-header-span-height ag-header-span-total"
+                            col-id="name"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Name
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-asc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-desc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-aasc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-adesc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="22"
+                            aria-sort="none"
+                            class="ag-focus-managed ag-header-cell ag-header-cell-sortable"
+                            col-id="source.displayName"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Display Name
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-asc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-desc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-aasc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-adesc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="25"
+                            aria-sort="none"
+                            class="ag-focus-managed ag-header-cell ag-header-cell-sortable ag-header-span-height ag-header-span-total"
+                            col-id="sourceId"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Source Id
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-asc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-desc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-aasc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-adesc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="26"
+                            aria-sort="none"
+                            class="ag-focus-managed ag-header-cell ag-header-cell-sortable ag-header-span-height ag-header-span-total"
+                            col-id="sourceIdVersion"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Source Id Version
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-asc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-desc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-aasc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-adesc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="33"
+                            class="ag-column-last ag-focus-managed ag-header-cell ag-header-span-height ag-header-span-total"
+                            col-id="SubClassOf"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Sub Class Of
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-header"
+                      role="rowgroup"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-group"
+                        role="row"
+                        tabindex="0"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="ag-floating-top ag-selectable"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-floating-top"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-floating-top-viewport ag-viewport"
+                      role="rowgroup"
+                    >
+                      <div
+                        class="ag-floating-top-container"
+                        role="presentation"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-floating-top"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-floating-top-full-width-container"
+                      role="rowgroup"
+                    />
+                  </div>
+                  <div
+                    class="ag-body ag-layout-normal"
+                    role="presentation"
+                  >
+                    <div
+                      class="ag-body-viewport ag-layout-normal ag-row-no-animation ag-selectable"
+                      role="presentation"
+                    >
+                      <div
+                        aria-hidden="true"
+                        class="ag-hidden ag-pinned-left-cols-container"
+                        role="rowgroup"
+                      />
+                      <div
+                        class="ag-center-cols-viewport ag-viewport"
+                        role="rowgroup"
+                      >
+                        <div
+                          class="ag-center-cols-container"
+                          role="presentation"
+                        >
+                          <div
+                            aria-rowindex="3"
+                            aria-selected="false"
+                            class="ag-row ag-row-even ag-row-first ag-row-last ag-row-level-0 ag-row-no-focus ag-row-position-absolute"
+                            role="row"
+                            row-index="0"
+                            tabindex="0"
+                          >
+                            <div
+                              aria-colindex="1"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing ag-column-first"
+                              col-id="preview"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-preview-XXXX"
+                                  role="presentation"
+                                >
+                                  undefined
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="21"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="name"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-name-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="22"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="source.displayName"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-source.displayName-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="25"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="sourceId"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-sourceId-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="26"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="sourceIdVersion"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-sourceIdVersion-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="33"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing ag-column-last"
+                              col-id="SubClassOf"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-SubClassOf-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden="true"
+                        class="ag-hidden ag-pinned-right-cols-container"
+                        role="rowgroup"
+                      />
+                      <div
+                        class="ag-full-width-container"
+                        role="rowgroup"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-body-vertical-scroll ag-scrollbar-invisible"
+                    >
+                      <div
+                        class="ag-body-vertical-scroll-viewport"
+                        data-ref="eViewport"
+                      >
+                        <div
+                          class="ag-body-vertical-scroll-container"
+                          data-ref="eContainer"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="ag-selectable ag-sticky-top"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-sticky-top"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-sticky-top-viewport ag-viewport"
+                      role="rowgroup"
+                    >
+                      <div
+                        class="ag-sticky-top-container"
+                        role="presentation"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-sticky-top"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-sticky-top-full-width-container"
+                      role="rowgroup"
+                    />
+                  </div>
+                  <div
+                    class="ag-selectable ag-sticky-bottom"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-sticky-bottom"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-sticky-bottom-viewport ag-viewport"
+                      role="rowgroup"
+                    >
+                      <div
+                        class="ag-sticky-bottom-container"
+                        role="presentation"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-sticky-bottom"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-sticky-bottom-full-width-container"
+                      role="rowgroup"
+                    />
+                  </div>
+                  <div
+                    class="ag-floating-bottom ag-selectable"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-floating-bottom"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-floating-bottom-viewport ag-viewport"
+                      role="rowgroup"
+                    >
+                      <div
+                        class="ag-floating-bottom-container"
+                        role="presentation"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-floating-bottom"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-floating-bottom-full-width-container"
+                      role="rowgroup"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="ag-body-horizontal-scroll ag-scrollbar-invisible"
+                  >
+                    <div
+                      class="ag-horizontal-left-spacer ag-scroller-corner"
+                      data-ref="eLeftSpacer"
+                    />
+                    <div
+                      class="ag-body-horizontal-scroll-viewport"
+                      data-ref="eViewport"
+                    >
+                      <div
+                        class="ag-body-horizontal-scroll-container"
+                        data-ref="eContainer"
+                      />
+                    </div>
+                    <div
+                      class="ag-horizontal-right-spacer ag-scroller-corner"
+                      data-ref="eRightSpacer"
+                    />
+                  </div>
+                  <div
+                    class="ag-hidden ag-overlay"
+                    role="presentation"
+                  >
+                    <div
+                      class="ag-overlay-panel"
+                      role="presentation"
+                    >
+                      <div
+                        class="ag-layout-normal ag-overlay-wrapper"
+                        data-ref="eOverlayWrapper"
+                        role="presentation"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="ag-tab-guard ag-tab-guard-bottom"
+                  role="presentation"
+                  tabindex="0"
+                />
+              </div>
+              <div
+                aria-hidden="true"
+                class="ag-focus-managed ag-hidden ag-paging-panel ag-unselectable"
+                id="ag-XXXX"
+              >
+                <div
+                  class="ag-tab-guard ag-tab-guard-top"
+                  role="presentation"
+                  tabindex="0"
+                />
+                <span
+                  class="ag-paging-page-size"
+                  data-ref="pageSizeComp"
+                />
+                <span
+                  class="ag-paging-row-summary-panel"
+                >
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    data-ref="lbFirstRowOnPage"
+                    id="ag-XXXX-first-row"
+                  />
+                  <span
+                    id="ag-XXXX-to"
+                  >
+                    to
+                  </span>
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    data-ref="lbLastRowOnPage"
+                    id="ag-XXXX-last-row"
+                  />
+                  <span
+                    id="ag-XXXX-of"
+                  >
+                    of
+                  </span>
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    data-ref="lbRecordCount"
+                    id="ag-XXXX-row-count"
+                  />
+                </span>
+                <span
+                  class="ag-paging-page-summary-panel"
+                  role="presentation"
+                >
+                  <div
+                    aria-label="First Page"
+                    class="ag-button ag-paging-button"
+                    data-ref="btFirst"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-first"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  <div
+                    aria-label="Previous Page"
+                    class="ag-button ag-paging-button"
+                    data-ref="btPrevious"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-previous"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  <span
+                    class="ag-paging-description"
+                  >
+                    <span
+                      id="ag-XXXX-start-page"
+                    >
+                      Page
+                    </span>
+                    <span
+                      class="ag-paging-number"
+                      data-ref="lbCurrent"
+                      id="ag-XXXX-start-page-number"
+                    />
+                    <span
+                      id="ag-XXXX-of-page"
+                    >
+                      of
+                    </span>
+                    <span
+                      class="ag-paging-number"
+                      data-ref="lbTotal"
+                      id="ag-XXXX-of-page-number"
+                    />
+                  </span>
+                  <div
+                    aria-label="Next Page"
+                    class="ag-button ag-paging-button"
+                    data-ref="btNext"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-next"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  <div
+                    aria-label="Last Page"
+                    class="ag-button ag-paging-button"
+                    data-ref="btLast"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-last"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                </span>
+                <div
+                  class="ag-tab-guard ag-tab-guard-bottom"
+                  role="presentation"
+                  tabindex="0"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiDrawer-anchorRight MuiDrawer-docked MuiDrawer-root css-XXXX-MuiDrawer-docked"
+        >
+          <div
+            class="MuiDrawer-paper MuiDrawer-paperAnchorDockedRight MuiDrawer-paperAnchorRight MuiPaper-elevation MuiPaper-elevation0 MuiPaper-root css-XXXX-MuiPaper-root-MuiDrawer-paper detail-drawer detail-drawer--closed"
+          />
+        </div>
+      </div>
+      <div
+        class="data-view__footer"
+      >
+        <div
+          class="footer__selected-records"
+        >
+          <p
+            class="MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root"
+          >
+            0
+             Record
+            s
+             Selected
+          </p>
+          <span
+            aria-label="click here for graph view"
+            class=""
+            data-mui-internal-clone-element="true"
+          >
+            <button
+              class="Mui-disabled MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root"
+              disabled=""
+              tabindex="-1"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-colorDisabled MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                data-testid="TimelineIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2"
+                />
+              </svg>
+            </button>
+          </span>
+        </div>
+        <p
+          class="MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root footer__total-rows"
+        >
+          Total Rows:
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`WithRows snapshot 1`] = `
+<div>
+  <div
+  >
+    <div
+      class="data-view"
+    >
+      <div
+        class="data-view__header"
+      >
+        <h5
+          class="MuiTypography-h5 MuiTypography-root css-XXXX-MuiTypography-root"
+        >
+          Search
+        </h5>
+        <span
+          aria-label="click here to see active filter groups"
+          class=""
+          data-mui-internal-clone-element="true"
+        >
+          <button
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+              data-testid="FilterListIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
+              />
+            </svg>
+          </button>
+        </span>
+        <div />
+        <button
+          aria-label="click here for table and export options"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root data-view__edit-filters"
+          data-mui-internal-clone-element="true"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-colorAction MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+            data-testid="MoreHorizIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2m-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="data-view__content"
+      >
+        <div
+          class="ag-theme-material data-table"
+          role="presentation"
+        >
+          <div
+            class="ag-theme-batchEditStyle-3 ag-theme-buttonStyle-4 ag-theme-checkboxStyle-5 ag-theme-columnDropStyle-9 ag-theme-iconSet-6 ag-theme-inputStyle-8 ag-theme-params-1 ag-theme-styleMaterial-10 ag-theme-tabStyle-7"
+          >
+            <div
+              class="ag-measurement-container"
+            >
+              <div
+              />
+              <div
+              />
+              <div
+              />
+              <div
+                class="ag-measurement-element-border"
+              />
+              <div
+                class="ag-measurement-element-border"
+              />
+              <div
+                class="ag-measurement-element-border"
+              />
+            </div>
+            <div
+              class="ag-layout-normal ag-ltr ag-root-wrapper"
+              grid-id="2"
+              role="presentation"
+            >
+              <div
+                class="ag-focus-managed ag-layout-normal ag-root-wrapper-body"
+                role="presentation"
+              >
+                <div
+                  class="ag-tab-guard ag-tab-guard-top"
+                  role="presentation"
+                  tabindex="0"
+                />
+                <div
+                  aria-colcount="33"
+                  aria-rowcount="-1"
+                  class="ag-body-vertical-content-no-gap ag-layout-normal ag-root ag-unselectable"
+                  role="grid"
+                >
+                  <div
+                    class="ag-header ag-header-allow-overflow ag-pivot-off"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-header"
+                      role="rowgroup"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-group"
+                        role="row"
+                        tabindex="0"
+                      />
+                    </div>
+                    <div
+                      class="ag-header-viewport"
+                      role="rowgroup"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="ag-header-container"
+                        role="presentation"
+                      >
+                        <div
+                          aria-rowindex="1"
+                          class="ag-header-row ag-header-row-group"
+                          role="row"
+                          tabindex="0"
+                        >
+                          <div
+                            aria-colindex="22"
+                            aria-colspan="3"
+                            aria-expanded="false"
+                            class="ag-header-group-cell ag-header-group-cell-with-group"
+                            col-id="source_0"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              class="ag-header-cell-comp-wrapper ag-header-cell-comp-wrapper-limited-height"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-header-group-cell-label"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-header-group-text"
+                                  data-ref="agLabel"
+                                  role="presentation"
+                                >
+                                  Source
+                                </span>
+                                <span
+                                  aria-hidden="true"
+                                  class="ag-header-expand-icon ag-header-expand-icon-expanded ag-header-icon ag-hidden"
+                                  data-ref="agOpened"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-expanded"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                                <span
+                                  aria-hidden="false"
+                                  class="ag-header-expand-icon ag-header-expand-icon-collapsed ag-header-icon"
+                                  data-ref="agClosed"
+                                >
+                                  <span
+                                    class="ag-icon ag-icon-contracted"
+                                    role="presentation"
+                                    unselectable="on"
+                                  />
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                            />
+                          </div>
+                        </div>
+                        <div
+                          aria-rowindex="2"
+                          class="ag-header-row ag-header-row-column"
+                          role="row"
+                          tabindex="0"
+                        >
+                          <div
+                            aria-colindex="1"
+                            class="ag-column-first ag-focus-managed ag-header-cell ag-header-span-height ag-header-span-total"
+                            col-id="preview"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Preview
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="21"
+                            aria-sort="none"
+                            class="ag-focus-managed ag-header-cell ag-header-cell-sortable ag-header-span-height ag-header-span-total"
+                            col-id="name"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Name
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-asc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-desc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-aasc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-adesc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="22"
+                            aria-sort="none"
+                            class="ag-focus-managed ag-header-cell ag-header-cell-sortable"
+                            col-id="source.displayName"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Display Name
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-asc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-desc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-aasc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-adesc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="25"
+                            aria-sort="none"
+                            class="ag-focus-managed ag-header-cell ag-header-cell-sortable ag-header-span-height ag-header-span-total"
+                            col-id="sourceId"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Source Id
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-asc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-desc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-aasc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-adesc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="26"
+                            aria-sort="none"
+                            class="ag-focus-managed ag-header-cell ag-header-cell-sortable ag-header-span-height ag-header-span-total"
+                            col-id="sourceIdVersion"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Source Id Version
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-asc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-desc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-aasc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-adesc"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            aria-colindex="33"
+                            class="ag-column-last ag-focus-managed ag-header-cell ag-header-span-height ag-header-span-total"
+                            col-id="SubClassOf"
+                            role="columnheader"
+                            tabindex="-1"
+                          >
+                            <div
+                              aria-hidden="false"
+                              class="ag-header-cell-resize"
+                              role="presentation"
+                            />
+                            <div
+                              class="ag-header-cell-comp-wrapper"
+                              role="presentation"
+                            >
+                              <div
+                                class="ag-cell-label-container"
+                                role="presentation"
+                              >
+                                <div
+                                  class="ag-header-cell-label"
+                                  data-ref="eLabel"
+                                  role="presentation"
+                                >
+                                  <span
+                                    class="ag-header-cell-text"
+                                    data-ref="eText"
+                                  >
+                                    Sub Class Of
+                                  </span>
+                                  <span
+                                    aria-hidden="true"
+                                    class="ag-filter-icon ag-header-icon ag-header-label-icon ag-hidden"
+                                    data-ref="eFilter"
+                                  >
+                                    <span
+                                      class="ag-icon ag-icon-filter"
+                                      role="presentation"
+                                      unselectable="on"
+                                    />
+                                  </span>
+                                  <span
+                                    class="ag-sort-indicator-container"
+                                    data-ref="eSortIndicator"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-order"
+                                      data-ref="eSortOrder"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-mixed-icon"
+                                      data-ref="eSortMixed"
+                                    >
+                                      <span
+                                        class="ag-icon ag-icon-none"
+                                        role="presentation"
+                                        unselectable="on"
+                                      />
+                                    </span>
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-ascending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteAsc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-absolute-descending-icon ag-sort-indicator-icon"
+                                      data-ref="eSortAbsoluteDesc"
+                                    />
+                                    <span
+                                      aria-hidden="true"
+                                      class="ag-hidden ag-sort-indicator-icon ag-sort-none-icon"
+                                      data-ref="eSortNone"
+                                    />
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-header"
+                      role="rowgroup"
+                    >
+                      <div
+                        aria-rowindex="1"
+                        class="ag-header-row ag-header-row-group"
+                        role="row"
+                        tabindex="0"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="ag-floating-top ag-selectable"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-floating-top"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-floating-top-viewport ag-viewport"
+                      role="rowgroup"
+                    >
+                      <div
+                        class="ag-floating-top-container"
+                        role="presentation"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-floating-top"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-floating-top-full-width-container"
+                      role="rowgroup"
+                    />
+                  </div>
+                  <div
+                    class="ag-body ag-layout-normal"
+                    role="presentation"
+                  >
+                    <div
+                      class="ag-body-viewport ag-layout-normal ag-row-no-animation ag-selectable"
+                      role="presentation"
+                    >
+                      <div
+                        aria-hidden="true"
+                        class="ag-hidden ag-pinned-left-cols-container"
+                        role="rowgroup"
+                      />
+                      <div
+                        class="ag-center-cols-viewport ag-viewport"
+                        role="rowgroup"
+                      >
+                        <div
+                          class="ag-center-cols-container"
+                          role="presentation"
+                        >
+                          <div
+                            aria-rowindex="3"
+                            aria-selected="false"
+                            class="ag-row ag-row-even ag-row-first ag-row-last ag-row-level-0 ag-row-no-focus ag-row-position-absolute"
+                            role="row"
+                            row-index="0"
+                            tabindex="0"
+                          >
+                            <div
+                              aria-colindex="1"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing ag-column-first"
+                              col-id="preview"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-preview-XXXX"
+                                  role="presentation"
+                                >
+                                  undefined
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="21"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="name"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-name-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="22"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="source.displayName"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-source.displayName-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="25"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="sourceId"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-sourceId-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="26"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing"
+                              col-id="sourceIdVersion"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-sourceIdVersion-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              aria-colindex="33"
+                              class="ag-cell ag-cell-normal-height ag-cell-not-inline-editing ag-column-last"
+                              col-id="SubClassOf"
+                              role="gridcell"
+                              tabindex="-1"
+                            >
+                              <div
+                                class="ag-cell-wrapper"
+                                role="presentation"
+                              >
+                                <span
+                                  class="ag-cell-value"
+                                  id="cell-SubClassOf-XXXX"
+                                  role="presentation"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden="true"
+                        class="ag-hidden ag-pinned-right-cols-container"
+                        role="rowgroup"
+                      />
+                      <div
+                        class="ag-full-width-container"
+                        role="rowgroup"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-body-vertical-scroll ag-scrollbar-invisible"
+                    >
+                      <div
+                        class="ag-body-vertical-scroll-viewport"
+                        data-ref="eViewport"
+                      >
+                        <div
+                          class="ag-body-vertical-scroll-container"
+                          data-ref="eContainer"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="ag-selectable ag-sticky-top"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-sticky-top"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-sticky-top-viewport ag-viewport"
+                      role="rowgroup"
+                    >
+                      <div
+                        class="ag-sticky-top-container"
+                        role="presentation"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-sticky-top"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-sticky-top-full-width-container"
+                      role="rowgroup"
+                    />
+                  </div>
+                  <div
+                    class="ag-selectable ag-sticky-bottom"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-sticky-bottom"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-sticky-bottom-viewport ag-viewport"
+                      role="rowgroup"
+                    >
+                      <div
+                        class="ag-sticky-bottom-container"
+                        role="presentation"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-sticky-bottom"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-sticky-bottom-full-width-container"
+                      role="rowgroup"
+                    />
+                  </div>
+                  <div
+                    class="ag-floating-bottom ag-selectable"
+                    role="presentation"
+                  >
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-left-floating-bottom"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-floating-bottom-viewport ag-viewport"
+                      role="rowgroup"
+                    >
+                      <div
+                        class="ag-floating-bottom-container"
+                        role="presentation"
+                      />
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="ag-hidden ag-pinned-right-floating-bottom"
+                      role="rowgroup"
+                    />
+                    <div
+                      class="ag-floating-bottom-full-width-container"
+                      role="rowgroup"
+                    />
+                  </div>
+                  <div
+                    aria-hidden="true"
+                    class="ag-body-horizontal-scroll ag-scrollbar-invisible"
+                  >
+                    <div
+                      class="ag-horizontal-left-spacer ag-scroller-corner"
+                      data-ref="eLeftSpacer"
+                    />
+                    <div
+                      class="ag-body-horizontal-scroll-viewport"
+                      data-ref="eViewport"
+                    >
+                      <div
+                        class="ag-body-horizontal-scroll-container"
+                        data-ref="eContainer"
+                      />
+                    </div>
+                    <div
+                      class="ag-horizontal-right-spacer ag-scroller-corner"
+                      data-ref="eRightSpacer"
+                    />
+                  </div>
+                  <div
+                    class="ag-hidden ag-overlay"
+                    role="presentation"
+                  >
+                    <div
+                      class="ag-overlay-panel"
+                      role="presentation"
+                    >
+                      <div
+                        class="ag-layout-normal ag-overlay-wrapper"
+                        data-ref="eOverlayWrapper"
+                        role="presentation"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="ag-tab-guard ag-tab-guard-bottom"
+                  role="presentation"
+                  tabindex="0"
+                />
+              </div>
+              <div
+                aria-hidden="true"
+                class="ag-focus-managed ag-hidden ag-paging-panel ag-unselectable"
+                id="ag-XXXX"
+              >
+                <div
+                  class="ag-tab-guard ag-tab-guard-top"
+                  role="presentation"
+                  tabindex="0"
+                />
+                <span
+                  class="ag-paging-page-size"
+                  data-ref="pageSizeComp"
+                />
+                <span
+                  class="ag-paging-row-summary-panel"
+                >
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    data-ref="lbFirstRowOnPage"
+                    id="ag-XXXX-first-row"
+                  />
+                  <span
+                    id="ag-XXXX-to"
+                  >
+                    to
+                  </span>
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    data-ref="lbLastRowOnPage"
+                    id="ag-XXXX-last-row"
+                  />
+                  <span
+                    id="ag-XXXX-of"
+                  >
+                    of
+                  </span>
+                  <span
+                    class="ag-paging-row-summary-panel-number"
+                    data-ref="lbRecordCount"
+                    id="ag-XXXX-row-count"
+                  />
+                </span>
+                <span
+                  class="ag-paging-page-summary-panel"
+                  role="presentation"
+                >
+                  <div
+                    aria-label="First Page"
+                    class="ag-button ag-paging-button"
+                    data-ref="btFirst"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-first"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  <div
+                    aria-label="Previous Page"
+                    class="ag-button ag-paging-button"
+                    data-ref="btPrevious"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-previous"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  <span
+                    class="ag-paging-description"
+                  >
+                    <span
+                      id="ag-XXXX-start-page"
+                    >
+                      Page
+                    </span>
+                    <span
+                      class="ag-paging-number"
+                      data-ref="lbCurrent"
+                      id="ag-XXXX-start-page-number"
+                    />
+                    <span
+                      id="ag-XXXX-of-page"
+                    >
+                      of
+                    </span>
+                    <span
+                      class="ag-paging-number"
+                      data-ref="lbTotal"
+                      id="ag-XXXX-of-page-number"
+                    />
+                  </span>
+                  <div
+                    aria-label="Next Page"
+                    class="ag-button ag-paging-button"
+                    data-ref="btNext"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-next"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                  <div
+                    aria-label="Last Page"
+                    class="ag-button ag-paging-button"
+                    data-ref="btLast"
+                    role="button"
+                    tabindex="0"
+                  >
+                    <span
+                      class="ag-icon ag-icon-last"
+                      role="presentation"
+                      unselectable="on"
+                    />
+                  </div>
+                </span>
+                <div
+                  class="ag-tab-guard ag-tab-guard-bottom"
+                  role="presentation"
+                  tabindex="0"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiDrawer-anchorRight MuiDrawer-docked MuiDrawer-root css-XXXX-MuiDrawer-docked"
+        >
+          <div
+            class="MuiDrawer-paper MuiDrawer-paperAnchorDockedRight MuiDrawer-paperAnchorRight MuiPaper-elevation MuiPaper-elevation0 MuiPaper-root css-XXXX-MuiPaper-root-MuiDrawer-paper detail-drawer detail-drawer--closed"
+          />
+        </div>
+      </div>
+      <div
+        class="data-view__footer"
+      >
+        <div
+          class="footer__selected-records"
+        >
+          <p
+            class="MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root"
+          >
+            0
+             Record
+            s
+             Selected
+          </p>
+          <span
+            aria-label="click here for graph view"
+            class=""
+            data-mui-internal-clone-element="true"
+          >
+            <button
+              class="Mui-disabled MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root"
+              disabled=""
+              tabindex="-1"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-colorDisabled MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                data-testid="TimelineIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2"
+                />
+              </svg>
+            </button>
+          </span>
+        </div>
+        <p
+          class="MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root footer__total-rows"
+        >
+          Total Rows:
+          2
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/views/DataView/components/Footer/index.tsx
+++ b/src/views/DataView/components/Footer/index.tsx
@@ -7,6 +7,7 @@ import {
   Typography,
 } from '@mui/material';
 import Tooltip from '@mui/material/Tooltip';
+import { useSnackbar } from 'notistack';
 import React, {
   useCallback,
 } from 'react';
@@ -15,7 +16,6 @@ import { NavigateFunction } from 'react-router';
 import { navigateToGraph } from '@/components/util';
 
 interface DataViewFooterProps {
-  onError?: (...args: unknown[]) => unknown;
   selectedRecords?: Record<string, unknown>[];
   statusMessage?: string;
   navigate: NavigateFunction;
@@ -23,12 +23,15 @@ interface DataViewFooterProps {
 }
 
 const DataViewFooter = ({
-  selectedRecords = [], onError, navigate, statusMessage = '', totalRows,
+  selectedRecords = [], navigate, statusMessage = '', totalRows,
 }: DataViewFooterProps) => {
+  const snackbar = useSnackbar();
+
   const handleSwapToGraph = useCallback(() => {
     const nodeRIDs = selectedRecords.map((node) => node['@rid']);
-    navigateToGraph(nodeRIDs, navigate, onError);
-  }, [navigate, onError, selectedRecords]);
+
+    navigateToGraph(nodeRIDs, navigate, snackbar);
+  }, [navigate, snackbar, selectedRecords]);
 
   return (
     <div className="data-view__footer">

--- a/src/views/DataView/index.stories.tsx
+++ b/src/views/DataView/index.stories.tsx
@@ -75,9 +75,8 @@ export const WithDetailsOpenError = WithRows.extend({
       ],
     },
   },
-  play: async ({ canvas, step, userEvent }) => {
-    await hasFinishedLoading({ canvas, step });
-    await userEvent.click(await canvas.findByText('source 1234'));
-    await expect(await canvas.findByText('BadRequestError')).toBeInTheDocument();
+  play: async ({ canvas, context }) => {
+    await WithDetailsOpen.play(context);
+    await expect(await canvas.findByText('An error occurred loading the details.', { exact: false })).toBeInTheDocument();
   },
 });

--- a/src/views/DataView/index.stories.tsx
+++ b/src/views/DataView/index.stories.tsx
@@ -1,0 +1,83 @@
+import { HttpResponse } from 'msw';
+import { expect } from 'storybook/test';
+
+import preview, {
+  hasFinishedLoading, http, view, ViewPreviewType,
+} from '#.storybook/preview';
+
+const meta = preview.type<ViewPreviewType>().meta({ ...view });
+
+export const NoRows = meta.story({
+  args: {
+    path: '/data/table',
+  },
+  play: async ({ canvas, step }) => {
+    await hasFinishedLoading({ canvas, step });
+    await expect(await canvas.findByText(/preview/i)).toBeInTheDocument();
+  },
+});
+
+export const WithRows = NoRows.extend({
+  args: {
+    path: '/data/table?%40class=Therapy&complex=eyJ0YXJnZXQiOiJUaGVyYXB5In0%253D',
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        http.gkb.query(() => [
+          {
+            '@class': 'Therapy', '@rid': '#111:111', count: 2, name: 'immunotherapy', source: { displayName: 'source 1234' },
+          },
+          {
+            '@class': 'Therapy', '@rid': '#111:222', count: 2, name: 'immunological therapy',
+          },
+        ]),
+      ],
+    },
+  },
+});
+
+export const WithError = WithRows.extend({
+  parameters: {
+    msw: {
+      handlers: [
+        http.gkb.query(() => HttpResponse.json({ message: 'Bad Request' }, { status: 400 })),
+      ],
+    },
+  },
+});
+
+export const WithDetailsOpen = WithRows.extend({
+  play: async ({ canvas, step, userEvent }) => {
+    await hasFinishedLoading({ canvas, step });
+    await userEvent.click(await canvas.findByText('source 1234'));
+    await expect(await canvas.findByText('immunotherapy (#111:111)')).toBeInTheDocument();
+  },
+});
+
+export const WithDetailsOpenError = WithRows.extend({
+  parameters: {
+    msw: {
+      handlers: [
+        http.gkb.query((body) => {
+          if (Array.isArray(body.target) && body.target.length === 1) {
+            return HttpResponse.json({ message: 'Bad Request' }, { status: 400 });
+          }
+          return [
+            {
+              '@class': 'Therapy', '@rid': '#111:111', count: 2, name: 'immunotherapy', source: { displayName: 'source 1234' },
+            },
+            {
+              '@class': 'Therapy', '@rid': '#111:222', count: 2, name: 'immunological therapy',
+            },
+          ];
+        }),
+      ],
+    },
+  },
+  play: async ({ canvas, step, userEvent }) => {
+    await hasFinishedLoading({ canvas, step });
+    await userEvent.click(await canvas.findByText('source 1234'));
+    await expect(await canvas.findByText('BadRequestError')).toBeInTheDocument();
+  },
+});

--- a/src/views/DataView/index.tsx
+++ b/src/views/DataView/index.tsx
@@ -23,8 +23,8 @@ import useGrid from '@/components/hooks/useGrid';
 import { GeneralRecordType } from '@/components/types';
 import { tuple } from '@/components/util';
 import api from '@/services/api';
+import { ErrorMessage } from '@/services/errors';
 import schema from '@/services/schema';
-import util from '@/services/util';
 import config from '@/static/config';
 
 import ActiveFilters from './components/ActiveFilters';
@@ -207,22 +207,12 @@ const DataView = (): React.JSX.Element => {
     gridApi.addEventListener('selectionChanged', handleSelectionChange);
   }, [grid.ref, initializeGrid, search, totalRows]);
 
-  const handleError = useCallback((err) => {
-    util.handleErrorSaveLocation(err, { navigate, pathname: '/data/table', search });
-  }, [navigate, search]);
-
   const { data: detailPanelRow, error } = useQuery({
     queryKey: tuple('/query', { target: [detailsRowId!], neighbors: DEFAULT_NEIGHBORS }),
     queryFn: async ({ queryKey: [, body] }) => api.query(body),
     enabled: Boolean(detailsRowId),
     select: (response) => response[0],
   });
-
-  useEffect(() => {
-    if (error) {
-      handleError(error);
-    }
-  }, [error, handleError]);
 
   const handleToggleDetailPanel = useCallback((params?: IRowNode | null) => {
     // no data or clicked link is a link property without a class model
@@ -389,6 +379,7 @@ const DataView = (): React.JSX.Element => {
           />
         </div>
         <DetailDrawer
+          error={<ErrorMessage error={error}>An error occurred loading the details.</ErrorMessage>}
           node={detailPanelRow}
           onClose={handleToggleDetailPanel}
         />

--- a/src/views/DataView/index.tsx
+++ b/src/views/DataView/index.tsx
@@ -395,7 +395,6 @@ const DataView = (): React.JSX.Element => {
       </div>
       <Footer
         navigate={navigate}
-        onError={handleError}
         selectedRecords={selectedRecords}
         statusMessage={statusMessage}
         totalRows={totalRows as number}

--- a/src/views/DataView/index.tsx
+++ b/src/views/DataView/index.tsx
@@ -13,7 +13,9 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import { useIsFetching, useQuery } from 'react-query';
+import {
+  QueryClient, useIsFetching, useQuery, useQueryClient,
+} from 'react-query';
 import { useLocation, useNavigate } from 'react-router';
 
 import DetailDrawer from '@/components/DetailDrawer';
@@ -82,6 +84,7 @@ interface GetRowsFromBlocksArgs {
   sortModel?: { colId: string; sort: string; }[];
   search: string;
   blockSize: number;
+  queryClient: QueryClient;
 }
 
 /**
@@ -93,6 +96,7 @@ const getRowsFromBlocks = async ({
   sortModel,
   search,
   blockSize,
+  queryClient,
 }: GetRowsFromBlocksArgs) => {
   const firstBlock = Math.floor(startRow / blockSize) * blockSize;
   const lastBlock = Math.floor((endRow - 1) / blockSize) * blockSize;
@@ -104,7 +108,7 @@ const getRowsFromBlocks = async ({
       search, skip: block, limit: blockSize, sortModel,
     });
 
-    blockRequests.push(api.queryClient.fetchQuery({
+    blockRequests.push(queryClient.fetchQuery({
       queryKey: tuple('/query', payload),
       queryFn: async ({ queryKey: [, body] }) => api.query(body),
     }));
@@ -113,7 +117,7 @@ const getRowsFromBlocks = async ({
   (await Promise.all(blockRequests)).forEach((block) => data.push(...block));
 
   data.forEach((record) => {
-    api.queryClient.setQueryData(
+    queryClient.setQueryData(
       ['/query', { target: [record['@rid']], neighbors: DEFAULT_NEIGHBORS }],
       [record],
     );
@@ -136,6 +140,7 @@ const DataView = (): React.JSX.Element => {
   const [optionsMenuAnchor, setOptionsMenuAnchor] = useState<HTMLButtonElement | null>(null);
   const [detailsRowId, setDetailsRowId] = useState<string | null>(null);
   const grid = useGrid();
+  const queryClient = useQueryClient();
 
   const payload = useMemo(() => getQueryPayload({
     search, count: true,
@@ -167,7 +172,7 @@ const DataView = (): React.JSX.Element => {
           sortModel,
         }) => {
           const result = await getRowsFromBlocks({
-            startRow, endRow, sortModel, search, blockSize: DEFAULT_BLOCK_SIZE,
+            startRow, endRow, sortModel, search, blockSize: DEFAULT_BLOCK_SIZE, queryClient,
           });
           return [result, totalRows] as const;
         };
@@ -179,7 +184,7 @@ const DataView = (): React.JSX.Element => {
           }).catch(() => failCallback());
       },
     });
-  }, [grid.ref, search, totalRows]);
+  }, [grid.ref, search, totalRows, queryClient]);
 
   useEffect(() => {
     // normalize the input query
@@ -281,6 +286,7 @@ const DataView = (): React.JSX.Element => {
         sortModel: gridApi.sortController.getSortModel(),
         search,
         blockSize: DEFAULT_BLOCK_SIZE,
+        queryClient,
       });
       // @ts-expect-error doesn't exist?
       const { gridOptions } = gridApi.getModel().gridOptionsWrapper;
@@ -305,7 +311,7 @@ const DataView = (): React.JSX.Element => {
 
       gridApi.setGridOption('datasource', tempDataSource);
     }
-  }, [grid.ref, initializeGrid, isExportingData, search, totalRows]);
+  }, [grid.ref, initializeGrid, isExportingData, search, totalRows, queryClient]);
 
   const detailPanelIsOpen = Boolean(detailPanelRow);
 

--- a/src/views/ErrorView/index.scss
+++ b/src/views/ErrorView/index.scss
@@ -11,12 +11,6 @@
     text-decoration: none;
   }
 
-  .stacktrace {
-    @include globals.code-block;
-    max-width: globals.$readable-max;
-    min-width: globals.$readable-min;
-  }
-
   h2 {
     color: globals.$palette__error--main;
     margin-top: 40px;
@@ -29,6 +23,3 @@
   }
 }
 
-#copy-button {
-  margin: 8px auto;
-}

--- a/src/views/ErrorView/index.tsx
+++ b/src/views/ErrorView/index.tsx
@@ -1,9 +1,7 @@
 import './index.scss';
 
-import AssignmentIcon from '@mui/icons-material/Assignment';
-import { Button, Tooltip, Typography } from '@mui/material';
-import copy from 'copy-to-clipboard';
-import React, { useCallback, useState } from 'react';
+import { Button, Typography } from '@mui/material';
+import React from 'react';
 import { Link, useLocation } from 'react-router';
 
 interface EmailReportErrorProps {
@@ -29,7 +27,6 @@ const EmailReportError = (props: EmailReportErrorProps) => {
  * View for displaying uncaught error messages.
  */
 const ErrorView = () => {
-  const [tooltipOpen, setTooltipOpen] = useState(false);
   const location = useLocation();
   const state = location.state ?? {};
 
@@ -37,7 +34,6 @@ const ErrorView = () => {
     error: {
       message = 'This is the default page where errors are reported if encountered',
       name = 'No Error Reported',
-      stacktrace = '',
       ...rest
     } = {},
   } = state;
@@ -54,16 +50,6 @@ error text: ${message}`;
       errorDetails = `${errorDetails}\n${key}: ${`${value}`.trim()}`;
     }
   });
-
-  // TODO: Remove this after alpha testing
-  if (stacktrace) {
-    errorDetails = `${errorDetails}\n\nstack trace:\n\n${stacktrace}`;
-  }
-
-  const handleCopyToClipboard = useCallback(() => {
-    setTooltipOpen(true);
-    copy(errorDetails);
-  }, [errorDetails]);
 
   return (
     <div className="error-wrapper">
@@ -82,28 +68,6 @@ error text: ${message}`;
         />
         .
       </Typography>
-      {stacktrace && (
-        <div className="stacktrace">
-          <pre>
-            <code>{errorDetails}</code>
-          </pre>
-          <Tooltip
-            disableHoverListener
-            onClose={() => setTooltipOpen(false)}
-            open={tooltipOpen}
-            title="Copied!"
-          >
-            <Button
-              id="copy-button"
-              onClick={handleCopyToClipboard}
-              variant="outlined"
-            >
-              Copy To Clipboard
-              <AssignmentIcon />
-            </Button>
-          </Tooltip>
-        </div>
-      )}
       <Link to="/">
         <Button color="primary" variant="contained">
           Home

--- a/src/views/ErrorView/index.tsx
+++ b/src/views/ErrorView/index.tsx
@@ -1,80 +1,53 @@
 import './index.scss';
 
 import { Button, Typography } from '@mui/material';
-import React from 'react';
-import { Link, useLocation } from 'react-router';
+import React, { ReactNode } from 'react';
+import { Link } from 'react-router';
 
-interface EmailReportErrorProps {
-  body: string;
-  linkText: string;
-  subject: string;
-}
+import { ReportErrorMessage } from '@/services/errors';
 
-const EmailReportError = (props: EmailReportErrorProps) => {
-  const { linkText, body, subject } = props;
-  return (
-    <a
-      href={`mailto:${window._env_.CONTACT_EMAIL}?subject=${encodeURIComponent(
-        subject,
-      )}&body=${encodeURIComponent(body)}`}
-    >
-      {linkText}
-    </a>
-  );
-};
+class ErrorBoundary extends React.Component<{ children: ReactNode }, { error: Error | null }> {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
 
-/**
- * View for displaying uncaught error messages.
- */
-const ErrorView = () => {
-  const location = useLocation();
-  const state = location.state ?? {};
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
 
-  const {
-    error: {
+  render() {
+    const { error } = this.state;
+    const { children } = this.props;
+
+    if (!error) {
+      return children;
+    }
+
+    const {
       message = 'This is the default page where errors are reported if encountered',
       name = 'No Error Reported',
-      ...rest
-    } = {},
-  } = state;
+    } = error;
 
-  const jiraLink = <a href={window._env_.CONTACT_TICKET_URL} rel="noopener noreferrer" target="_blank">Ticket/Issue</a>;
+    return (
+      <div className="error-wrapper">
+        <Typography variant="h2">
+          {name}
+        </Typography>
+        <Typography variant="h3">
+          {message}
+        </Typography>
+        <Typography paragraph>
+          <ReportErrorMessage error={error} />
+        </Typography>
+        <Link to="/">
+          <Button color="primary" variant="contained">
+            Home
+          </Button>
+        </Link>
+      </div>
+    );
+  }
+}
 
-  let errorDetails = `Error Details (Please include in error reports)
-version: ${process.env.npm_package_version || process.env.REACT_APP_VERSION || ''}
-error name: ${name}
-error text: ${message}`;
-
-  Object.entries(rest).forEach(([key, value]) => {
-    if (value) {
-      errorDetails = `${errorDetails}\n${key}: ${`${value}`.trim()}`;
-    }
-  });
-
-  return (
-    <div className="error-wrapper">
-      <Typography variant="h2">
-        {name}
-      </Typography>
-      <Typography variant="h3">
-        {message}
-      </Typography>
-      <Typography paragraph>
-        Report this error in a {jiraLink} ticket or email us at&nbsp;
-        <EmailReportError
-          body={errorDetails}
-          linkText={window._env_.CONTACT_EMAIL}
-          subject={`${name}: ${message}`}
-        />
-        .
-      </Typography>
-      <Link to="/">
-        <Button color="primary" variant="contained">
-          Home
-        </Button>
-      </Link>
-    </div>
-  );
-};
-
-export default ErrorView;
+export default ErrorBoundary;

--- a/src/views/GraphView/__snapshots__/index.stories.tsx.snap
+++ b/src/views/GraphView/__snapshots__/index.stories.tsx.snap
@@ -1,0 +1,722 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GraphNoNodes snapshot 1`] = `
+<div>
+  <div
+  >
+    <div
+      class="data-view"
+    >
+      <div
+        class="data-view__content--graph-view"
+      />
+      <div
+        class="data-view__footer"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GraphOneNode snapshot 1`] = `
+<div>
+  <div
+  >
+    <div
+      class="data-view"
+    >
+      <div
+        class="data-view__content--graph-view"
+      >
+        <div
+          class="graph-wrapper"
+        >
+          <div
+            class="toolbar"
+          >
+            <button
+              aria-label="Graph options"
+              class="MuiButtonBase-root MuiIconButton-colorPrimary MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              id="graph-options-btn"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                data-testid="SettingsIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6"
+                />
+              </svg>
+            </button>
+            <button
+              aria-label="Copy share-able URL to clip-board"
+              class="MuiButtonBase-root MuiIconButton-colorPrimary MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              id="clipboard-copy-btn"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                data-testid="SettingsRemoteIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15 9H9c-.55 0-1 .45-1 1v12c0 .55.45 1 1 1h6c.55 0 1-.45 1-1V10c0-.55-.45-1-1-1m-3 6c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2M7.05 6.05l1.41 1.41C9.37 6.56 10.62 6 12 6s2.63.56 3.54 1.46l1.41-1.41C15.68 4.78 13.93 4 12 4s-3.68.78-4.95 2.05M12 0C8.96 0 6.21 1.23 4.22 3.22l1.41 1.41C7.26 3.01 9.51 2 12 2s4.74 1.01 6.36 2.64l1.41-1.41C17.79 1.23 15.04 0 12 0"
+                />
+              </svg>
+            </button>
+            <div
+              aria-label="Rerun Layout"
+              class="refresh-wrapper"
+              data-mui-internal-clone-element="true"
+            >
+              <button
+                class="MuiButtonBase-root MuiIconButton-colorPrimary MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root"
+                tabindex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                  data-testid="RefreshIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            class="svg-wrapper"
+          >
+            <svg
+              height="682"
+              width="1280"
+            >
+              <defs>
+                <marker
+                  id="endArrow"
+                  markerHeight="4"
+                  markerUnits="strokeWidth"
+                  markerWidth="4"
+                  orient="auto"
+                  refY="1.5"
+                  viewBox="0 0 4 3"
+                >
+                  <path
+                    d="M 0 0 L 4 1.5 L 0 3 z"
+                    fill="#555"
+                  />
+                </marker>
+              </defs>
+              <g>
+                <g
+                  transform="translate(726.6025403784439,291)"
+                >
+                  <text
+                  >
+                    <tspan
+                      class="node-name"
+                      dy="28"
+                      id="node-#123:123-label"
+                    >
+                      immunotherapy
+                    </tspan>
+                  </text>
+                  <circle
+                    cx="0"
+                    cy="0"
+                    fill="#fff"
+                    r="16"
+                  />
+                  <circle
+                    aria-labelledby="node-#123:123-label"
+                    class="node"
+                    cx="0"
+                    cy="0"
+                    fill="#72b14d"
+                    r="16"
+                    role="button"
+                  />
+                </g>
+              </g>
+            </svg>
+          </div>
+          <div
+            class="legend-wrapper"
+          >
+            <div
+              class="MuiPaper-elevation MuiPaper-elevation2 MuiPaper-root MuiPaper-rounded css-XXXX-MuiPaper-root"
+            >
+              <div
+                class="legend-content"
+              >
+                <div
+                  class="legend-header"
+                >
+                  <div
+                    class="legend-header-text"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-XXXX-MuiTypography-root"
+                    >
+                      Nodes
+                    </h6>
+                    <span
+                      class="MuiTypography-caption MuiTypography-root css-XXXX-MuiTypography-root"
+                    >
+                      (Class)
+                    </span>
+                  </div>
+                  <button
+                    aria-label="nodes legend"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root"
+                    name="nodesLegend"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                      data-testid="CloseIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+                <ul
+                  class="MuiList-dense MuiList-padding MuiList-root css-XXXX-MuiList-root node-colors"
+                >
+                  <li
+                    class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root"
+                  >
+                    <div
+                      class="MuiListItemIcon-root css-XXXX-MuiListItemIcon-root"
+                    >
+                      <div
+                        class="color-chip"
+                      />
+                    </div>
+                    <div
+                      class="MuiListItemText-dense MuiListItemText-root css-XXXX-MuiListItemText-root"
+                    >
+                      <span
+                        class="MuiListItemText-primary MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root"
+                      >
+                        Therapy
+                      </span>
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="data-view__footer"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GraphOneNodeDetailsOpen snapshot 1`] = `
+<div>
+  <div
+  >
+    <div
+      class="data-view data-view--squished"
+    >
+      <div
+        class="data-view__content--graph-view"
+      >
+        <div
+          class="graph-wrapper"
+        >
+          <div
+            class="toolbar"
+          >
+            <button
+              aria-label="Graph options"
+              class="MuiButtonBase-root MuiIconButton-colorPrimary MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              id="graph-options-btn"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                data-testid="SettingsIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6"
+                />
+              </svg>
+            </button>
+            <button
+              aria-label="Copy share-able URL to clip-board"
+              class="MuiButtonBase-root MuiIconButton-colorPrimary MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              id="clipboard-copy-btn"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                data-testid="SettingsRemoteIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15 9H9c-.55 0-1 .45-1 1v12c0 .55.45 1 1 1h6c.55 0 1-.45 1-1V10c0-.55-.45-1-1-1m-3 6c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2M7.05 6.05l1.41 1.41C9.37 6.56 10.62 6 12 6s2.63.56 3.54 1.46l1.41-1.41C15.68 4.78 13.93 4 12 4s-3.68.78-4.95 2.05M12 0C8.96 0 6.21 1.23 4.22 3.22l1.41 1.41C7.26 3.01 9.51 2 12 2s4.74 1.01 6.36 2.64l1.41-1.41C17.79 1.23 15.04 0 12 0"
+                />
+              </svg>
+            </button>
+            <div
+              aria-label="Rerun Layout"
+              class="refresh-wrapper"
+              data-mui-internal-clone-element="true"
+            >
+              <button
+                class="MuiButtonBase-root MuiIconButton-colorPrimary MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root"
+                tabindex="0"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                  data-testid="RefreshIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            class="svg-wrapper"
+          >
+            <svg
+              height="682"
+              width="1280"
+            >
+              <defs>
+                <marker
+                  id="endArrow"
+                  markerHeight="4"
+                  markerUnits="strokeWidth"
+                  markerWidth="4"
+                  orient="auto"
+                  refY="1.5"
+                  viewBox="0 0 4 3"
+                >
+                  <path
+                    d="M 0 0 L 4 1.5 L 0 3 z"
+                    fill="#555"
+                  />
+                </marker>
+              </defs>
+              <g>
+                <g
+                  transform="translate(726.6025403784439,291)"
+                >
+                  <text
+                  >
+                    <tspan
+                      class="node-name"
+                      dy="28"
+                      id="node-#123:123-label"
+                    >
+                      immunotherapy
+                    </tspan>
+                  </text>
+                  <circle
+                    cx="0"
+                    cy="0"
+                    fill="#fff"
+                    r="16"
+                  />
+                  <circle
+                    aria-labelledby="node-#123:123-label"
+                    class="node"
+                    cx="0"
+                    cy="0"
+                    fill="#26328C"
+                    r="16"
+                    role="button"
+                  />
+                </g>
+                <g
+                  class="actions-node"
+                  transform="translate(726.6025403784439,291)"
+                >
+                  <g
+                    aria-label="details"
+                    id="details"
+                  >
+                    <path
+                      d="M -39.597979746446654 39.59797974644666 A 56 56 0 0 0 39.59797974644666 39.597979746446654 L 11.313708498984761 11.31370849898476 A 16 16 0 0 1 -11.31370849898476 11.313708498984761 L -39.597979746446654 39.59797974644666"
+                      fill="rgba(255,255,255,0.9)"
+                      stroke="#ccc"
+                    />
+                    <g
+                      fill="#ccc"
+                      transform="translate(-9.6, 26.240000000000002) scale(0.8)"
+                    >
+                      <path
+                        d="M19 3h-4.18C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm2 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z"
+                      />
+                      <text
+                        dominant-baseline="central"
+                        dx="12"
+                        dy="28"
+                        font-size="7"
+                        text-anchor="middle"
+                      >
+                        (Details)
+                      </text>
+                    </g>
+                  </g>
+                  <g
+                    aria-label="close"
+                    id="close"
+                  >
+                    <path
+                      d="M -39.59797974644667 -39.597979746446654 A 56 56 0 0 0 -39.597979746446654 39.59797974644666 L -11.31370849898476 11.313708498984761 A 16 16 0 0 1 -11.313708498984763 -11.31370849898476 L -39.59797974644667 -39.597979746446654"
+                      fill="rgba(255,255,255,0.9)"
+                      stroke="#ccc"
+                    />
+                    <g
+                      fill="#555"
+                      transform="translate(-45.440000000000005, -9.599999999999998) scale(0.8)"
+                    >
+                      <path
+                        d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
+                      />
+                      <text
+                        dominant-baseline="central"
+                        dx="12"
+                        dy="28"
+                        font-size="7"
+                        text-anchor="middle"
+                      >
+                        (Close)
+                      </text>
+                    </g>
+                  </g>
+                  <g
+                    aria-label="expand"
+                    id="expand"
+                  >
+                    <path
+                      d="M 39.597979746446654 -39.59797974644667 A 56 56 0 0 0 -39.59797974644667 -39.597979746446654 L -11.313708498984763 -11.31370849898476 A 16 16 0 0 1 11.313708498984758 -11.313708498984763 L 39.597979746446654 -39.59797974644667"
+                      fill="rgba(255,255,255,0.9)"
+                      stroke="#ccc"
+                    />
+                    <g
+                      fill="#555"
+                      transform="translate(-9.600000000000009, -45.440000000000005) scale(0.8)"
+                    >
+                      <path
+                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z"
+                      />
+                      <text
+                        dominant-baseline="central"
+                        dx="12"
+                        dy="28"
+                        font-size="7"
+                        text-anchor="middle"
+                      >
+                        (Expand)
+                      </text>
+                    </g>
+                  </g>
+                  <g
+                    aria-label="hide"
+                    id="hide"
+                  >
+                    <path
+                      d="M 39.59797974644667 39.597979746446654 A 56 56 0 0 0 39.597979746446654 -39.59797974644667 L 11.313708498984758 -11.313708498984763 A 16 16 0 0 1 11.313708498984763 11.313708498984758 L 39.59797974644667 39.597979746446654"
+                      fill="rgba(255,255,255,0.9)"
+                      stroke="#ccc"
+                    />
+                    <g
+                      fill="#ccc"
+                      transform="translate(26.240000000000002, -9.60000000000001) scale(0.8)"
+                    >
+                      <path
+                        d="M12 7c2.76 0 5 2.24 5 5 0 .65-.13 1.26-.36 1.83l2.92 2.92c1.51-1.26 2.7-2.89 3.43-4.75-1.73-4.39-6-7.5-11-7.5-1.4 0-2.74.25-3.98.7l2.16 2.16C10.74 7.13 11.35 7 12 7zM2 4.27l2.28 2.28.46.46C3.08 8.3 1.78 10.02 1 12c1.73 4.39 6 7.5 11 7.5 1.55 0 3.03-.3 4.38-.84l.42.42L19.73 22 21 20.73 3.27 3 2 4.27zM7.53 9.8l1.55 1.55c-.05.21-.08.43-.08.65 0 1.66 1.34 3 3 3 .22 0 .44-.03.65-.08l1.55 1.55c-.67.33-1.41.53-2.2.53-2.76 0-5-2.24-5-5 0-.79.2-1.53.53-2.2zm4.31-.78l3.15 3.15.02-.16c0-1.66-1.34-3-3-3l-.17.01z"
+                      />
+                      <text
+                        dominant-baseline="central"
+                        dx="12"
+                        dy="28"
+                        font-size="7"
+                        text-anchor="middle"
+                      >
+                        (Hide)
+                      </text>
+                    </g>
+                  </g>
+                </g>
+              </g>
+            </svg>
+          </div>
+        </div>
+        <div
+          class="MuiDrawer-anchorRight MuiDrawer-docked MuiDrawer-root css-XXXX-MuiDrawer-docked"
+        >
+          <div
+            class="MuiDrawer-paper MuiDrawer-paperAnchorDockedRight MuiDrawer-paperAnchorRight MuiPaper-elevation MuiPaper-elevation0 MuiPaper-root css-XXXX-MuiPaper-root-MuiDrawer-paper detail-drawer"
+          >
+            <div
+              class="detail-drawer__content"
+            >
+              <div
+                class="detail-drawer__heading"
+              >
+                <div>
+                  <h2
+                    class="MuiTypography-h2 MuiTypography-root css-XXXX-MuiTypography-root"
+                  >
+                    immunotherapy (#123:123)
+                  </h2>
+                </div>
+                <a
+                  data-discover="true"
+                  href="/view/Therapy/123:123"
+                  target="_blank"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                      data-testid="OpenInNewIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
+                      />
+                    </svg>
+                  </button>
+                </a>
+                <button
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                    data-testid="CloseIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <hr
+                class="MuiDivider-fullWidth MuiDivider-root css-XXXX-MuiDivider-root"
+              />
+              <li
+                class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root"
+              >
+                <div
+                  class="MuiListItemText-dense MuiListItemText-root css-XXXX-MuiListItemText-root detail-li-text"
+                >
+                  <span
+                    class="MuiListItemText-primary MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root"
+                  >
+                    <div
+                      class="detail-identifiers"
+                    >
+                      <p
+                        class="MuiTypography-body1 MuiTypography-root css-XXXX-MuiTypography-root"
+                      >
+                        Name
+                      </p>
+                      <p
+                        class="MuiTypography-body1 MuiTypography-root css-XXXX-MuiTypography-root"
+                      >
+                        immunotherapy
+                      </p>
+                    </div>
+                  </span>
+                </div>
+              </li>
+              <hr
+                class="MuiDivider-fullWidth MuiDivider-root css-XXXX-MuiDivider-root"
+              />
+              <li
+                class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root"
+              >
+                <div
+                  class="MuiListItemText-dense MuiListItemText-root css-XXXX-MuiListItemText-root"
+                >
+                  <p
+                    class="MuiTypography-body1 MuiTypography-root css-XXXX-MuiTypography-root"
+                  >
+                    Metadata
+                  </p>
+                </div>
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                  data-testid="ExpandMoreIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                  />
+                </svg>
+              </li>
+              <hr
+                class="MuiDivider-fullWidth MuiDivider-root css-XXXX-MuiDivider-root"
+              />
+              <li
+                class="MuiListSubheader-gutters MuiListSubheader-root MuiListSubheader-sticky css-XXXX-MuiListSubheader-root detail-drawer__relationships-subheader"
+              >
+                Relationships
+              </li>
+              <ul
+                class="MuiList-padding MuiList-root css-XXXX-MuiList-root"
+              >
+                <li
+                  class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root detail-link-wrapper"
+                >
+                  <div
+                    class="MuiListItemIcon-root css-XXXX-MuiListItemIcon-root"
+                  >
+                    <div
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-colorAction MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                        data-testid="LinkIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1M8 13h8v-2H8zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiListItemText-dense MuiListItemText-multiline MuiListItemText-root css-XXXX-MuiListItemText-root detail-li-text"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-XXXX-MuiTypography-root"
+                    >
+                      immunological therapy [c15262] (#124:124)
+                    </h6>
+                    <p
+                      class="MuiListItemText-secondary MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root"
+                    >
+                      HasAlias
+                    </p>
+                  </div>
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                    data-testid="ExpandMoreIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                    />
+                  </svg>
+                </li>
+                <li
+                  class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root detail-link-wrapper"
+                >
+                  <div
+                    class="MuiListItemIcon-root css-XXXX-MuiListItemIcon-root"
+                  >
+                    <div
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-colorAction MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                        data-testid="LinkIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1M8 13h8v-2H8zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiListItemText-dense MuiListItemText-multiline MuiListItemText-root css-XXXX-MuiListItemText-root detail-li-text"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-XXXX-MuiTypography-root"
+                    >
+                      immunological [c15262] (#122:122)
+                    </h6>
+                    <p
+                      class="MuiListItemText-secondary MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root"
+                    >
+                      HasAlias
+                    </p>
+                  </div>
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                    data-testid="ExpandMoreIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                    />
+                  </svg>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="data-view__footer"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/src/views/GraphView/components/GraphComponent/GraphActionsNode.tsx
+++ b/src/views/GraphView/components/GraphComponent/GraphActionsNode.tsx
@@ -99,10 +99,13 @@ function GraphActionsNode(props: GraphActionsNodeProps) {
     const dx = DETAILS_RING_RADIUS * Math.cos(angle) * ICON_POSITION_COEFFICIENT;
     const dy = DETAILS_RING_RADIUS * Math.sin(angle) * ICON_POSITION_COEFFICIENT;
 
+    const id = option.name.toLowerCase();
+
     actionsRing.push((
       <g
         key={option.name}
-        id={option.name.toLowerCase()}
+        aria-label={id}
+        id={id}
         onClick={option.action}
         style={{ cursor: 'pointer' }}
       >

--- a/src/views/GraphView/components/GraphComponent/GraphComponent.tsx
+++ b/src/views/GraphView/components/GraphComponent/GraphComponent.tsx
@@ -105,7 +105,6 @@ interface GraphComponentProps {
   handleDetailDrawerClose: () => void;
   /** Method to handle opening of detail drawer. */
   handleDetailDrawerOpen: (node: GraphObj | null) => void;
-  handleError: (...args: unknown[]) => unknown;
   /** record ID of node currently selected for detail viewing. in the initial query. */
   detail?: Record<string, unknown> | null;
   /** list of valid edge classes. */
@@ -179,7 +178,7 @@ function GraphComponent(props: GraphComponentProps) {
    * node coloring to avoid sending full graph state over limited URL.
    */
   const saveGraphStatetoURL = (graphNodes) => {
-    const { handleGraphStateSave, handleError } = props;
+    const { handleGraphStateSave } = props;
     const withoutStatementData:{ '@rid': string }[] = [];
 
     /* Because properties types like linkset are uni-directional, we need to
@@ -206,7 +205,7 @@ function GraphComponent(props: GraphComponentProps) {
         handleGraphStateSave(nodeRIDs);
       }
     } catch (err) {
-      handleError(err);
+      snackbar.enqueueSnackbar(`An error occurred saving graph state. ${(err as Error).toString()}`, { variant: 'error' });
     }
   };
 
@@ -848,7 +847,7 @@ function GraphComponent(props: GraphComponentProps) {
   };
 
   const handleExpandNode = async ({ data: node }) => {
-    const { handleError, getRecord } = props;
+    const { getRecord } = props;
 
     try {
       const record = await getRecord(node['@rid']);
@@ -858,8 +857,7 @@ function GraphComponent(props: GraphComponentProps) {
         update({ data });
       }
     } catch (err) {
-      console.error(err);
-      handleError(err);
+      snackbar.enqueueSnackbar(`An error attempting to expand node. ${(err as Error).toString()}`, { variant: 'error' });
     }
   };
 

--- a/src/views/GraphView/components/GraphComponent/GraphNodeDisplay/GraphNodeDisplay.tsx
+++ b/src/views/GraphView/components/GraphComponent/GraphNodeDisplay/GraphNodeDisplay.tsx
@@ -5,7 +5,6 @@ import * as d3Drag from 'd3-drag';
 import * as d3Select from 'd3-selection';
 import React, { useEffect, useRef } from 'react';
 
-import { GeneralRecordType } from '@/components/types';
 import schema from '@/services/schema';
 import config from '@/static/config';
 
@@ -31,7 +30,7 @@ interface GraphNodeDisplayProps {
   /** Property to label node by. */
   labelKey?: string;
   /** Node to be rendered. */
-  node: GraphNode | { data: GeneralRecordType; x: number; y: number; };
+  node: GraphNode;
 }
 
 /**
@@ -75,7 +74,7 @@ function GraphNodeDisplay(props: GraphNodeDisplayProps) {
   if (labelKey === 'preview') {
     label = schemaDefn.getPreview(node.data as GraphRecord);
   } else if (labelKey) {
-    label = node instanceof GraphNode ? node.getLabel(labelKey) : node.data[labelKey];
+    label = node.getLabel(labelKey);
 
     if (typeof label === 'object') {
       label = schema.getLabel(label);
@@ -96,6 +95,8 @@ function GraphNodeDisplay(props: GraphNodeDisplayProps) {
     opacity = FADED_OPACITY;
   }
 
+  const id = node.getId();
+
   return (
     <g
       ref={nodeSVG}
@@ -106,7 +107,7 @@ function GraphNodeDisplay(props: GraphNodeDisplayProps) {
           opacity,
         }}
       >
-        <tspan className="node-name" dy={28}>
+        <tspan className="node-name" dy={28} id={`node-${id}-label`}>
           {label}
         </tspan>
       </text>
@@ -118,12 +119,14 @@ function GraphNodeDisplay(props: GraphNodeDisplayProps) {
         r={NODE_RADIUS}
       />
       <circle
+        aria-labelledby={`node-${id}-label`}
         className="node"
         cx={0}
         cy={0}
         fill={color}
         onClick={handleClick}
         r={NODE_RADIUS}
+        role="button"
         style={{
           opacity,
         }}

--- a/src/views/GraphView/index.stories.tsx
+++ b/src/views/GraphView/index.stories.tsx
@@ -79,6 +79,7 @@ export const GraphOneNodeDetailsOpen = GraphOneNode.extend({
     const node = await canvas.findByLabelText('immunotherapy');
     await userEvent.click(node);
     await expect(await canvas.findByText('immunological therapy [c15262] (#124:124)')).toBeInTheDocument();
+    await hasFinishedLoading({ canvas, step });
   },
 });
 

--- a/src/views/GraphView/index.stories.tsx
+++ b/src/views/GraphView/index.stories.tsx
@@ -1,0 +1,98 @@
+import { expect } from 'storybook/test';
+
+import { GeneralRecordType } from '@/components/types';
+import preview, {
+  hasFinishedLoading,
+  http,
+  view, ViewPreviewType,
+} from '#.storybook/preview';
+
+const meta = preview.type<ViewPreviewType>().meta({ ...view });
+
+export const GraphNoNodes = meta.story({
+  args: {
+    path: '/data/graph',
+  },
+});
+
+export const GraphOneNode = meta.story({
+  args: {
+    path: `/data/graph?nodes=${encodeURIComponent(btoa(JSON.stringify(['#123:123'])))}`,
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        http.gkb.query((body) => {
+          const rids = body.target as string[];
+          const mainRecord = {
+            '@class': 'Therapy',
+            '@rid': '#123:123',
+            name: 'immunotherapy',
+            in_AliasOf: [
+              {
+                in: '#123:123',
+                out: {
+                  displayName: 'immunological therapy [c15262]',
+                  name: 'immunological therapy',
+                  alias: true,
+                  '@class': 'Therapy',
+                  '@rid': '#124:124',
+                },
+                '@class': 'AliasOf',
+                '@rid': '#68:68',
+              },
+              {
+                in: '#123:123',
+                out: {
+                  displayName: 'immunological [c15262]',
+                  name: 'immunological',
+                  alias: true,
+                  '@class': 'Therapy',
+                  '@rid': '#122:122',
+                },
+                '@class': 'AliasOf',
+                '@rid': '#65:65',
+              },
+            ],
+          };
+          const recordsById: Record<string, unknown> = {
+            [mainRecord['@rid']]: mainRecord,
+          };
+          mainRecord.in_AliasOf.forEach((edge) => {
+            recordsById[edge['@rid']] = { ...edge, out: { ...edge.out } };
+            recordsById[edge.out['@rid']] = { ...edge.out };
+          });
+          return rids.map((rid) => recordsById[rid]).filter(Boolean) as GeneralRecordType[];
+        }),
+      ],
+    },
+  },
+  play: async ({ canvas, step }) => {
+    await hasFinishedLoading({ canvas, step });
+    await expect(await canvas.findByLabelText('immunotherapy')).toBeInTheDocument();
+  },
+});
+
+export const GraphOneNodeDetailsOpen = GraphOneNode.extend({
+  play: async ({ canvas, step, userEvent }) => {
+    await hasFinishedLoading({ canvas, step });
+    const node = await canvas.findByLabelText('immunotherapy');
+    await userEvent.click(node);
+    await expect(await canvas.findByText('immunological therapy [c15262] (#124:124)')).toBeInTheDocument();
+  },
+});
+
+export const GraphOneNodeExpanded = GraphOneNode.extend({
+  play: async ({ canvas, userEvent, context }) => {
+    await GraphOneNodeDetailsOpen.play(context);
+    await userEvent.click(await canvas.findByLabelText('expand'));
+    await expect(await canvas.findByText('immunological therapy [c15262]')).toBeInTheDocument();
+    await expect(await canvas.findByText('immunological [c15262]')).toBeInTheDocument();
+  },
+  tags: ['flaky'],
+  parameters: {
+    // behaviour of graph component is not consistent without a full page refresh
+    // so not possible to use snapshots currently
+    snapshot: false,
+  },
+});

--- a/src/views/GraphView/index.tsx
+++ b/src/views/GraphView/index.tsx
@@ -14,6 +14,7 @@ import DetailDrawer from '@/components/DetailDrawer';
 import { GeneralRecordType } from '@/components/types';
 import { getNodeRIDsFromURL, navigateToGraph, tuple } from '@/components/util';
 import api from '@/services/api';
+import { ErrorMessage } from '@/services/errors';
 import schema from '@/services/schema';
 import util from '@/services/util';
 import config from '@/static/config';
@@ -30,34 +31,38 @@ const GraphView = () => {
   const { search } = useLocation();
   const navigate = useNavigate();
   const isLoading = useIsFetching();
-  const [detailPanelRow, setDetailPanelRow] = useState<GeneralRecordType | null>(null);
+  const [detailPanelRid, setDetailPanelRid] = useState<string | null>(null);
   // the existing behaviour of the graph relies on this not changing even when the url *is* updated (TODO fix logic so this can update)
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const recordIds = useMemo(() => getNodeRIDsFromURL(`${window.location.origin}${search}`), []);
   const queryClient = useQueryClient();
   const snackbar = useSnackbar();
 
-  const handleError = useCallback((err) => {
-    util.handleErrorSaveLocation(err, { navigate, pathname: '/data/table', search });
-  }, [navigate, search]);
-
-  const { data: graphData } = useQuery({
+  const graphQuery = useQuery({
     queryKey: tuple('/query', { target: recordIds, neighbors: DEFAULT_NEIGHBORS }),
     queryFn: async ({ queryKey: [, body] }) => api.query(body),
     enabled: Boolean(recordIds.length),
     select: (response) => util.hashRecordsByRID(response),
+    throwOnError: true,
+  });
+
+  const detailsQuery = useQuery({
+    queryKey: tuple('/query', { target: [detailPanelRid!], neighbors: DEFAULT_NEIGHBORS }),
+    queryFn: async ({ queryKey: [, body] }) => api.query(body),
+    enabled: Boolean(detailPanelRid),
+    select: (response) => response[0],
   });
 
   useEffect(() => {
-    if (graphData) {
-      Object.keys(graphData).forEach((recordId) => {
+    if (graphQuery.data) {
+      Object.keys(graphQuery.data).forEach((recordId) => {
         queryClient.setQueryData(
           [{ target: [recordId], neighbors: DEFAULT_NEIGHBORS }],
-          [graphData[recordId]],
+          [graphQuery.data[recordId]],
         );
       });
     }
-  }, [graphData, queryClient]);
+  }, [graphQuery.data, queryClient]);
 
   /**
    * Opens the right-hand panel that shows details of a given record
@@ -67,25 +72,11 @@ const GraphView = () => {
 
     // no data or clicked link is a link property without a class model
     if (!detailData || detailData.isLinkProp) {
-      setDetailPanelRow(null);
+      setDetailPanelRid(null);
     } else {
-      try {
-        const [fullRecord] = await queryClient.fetchQuery({
-          queryKey: tuple('/query', { target: [detailData['@rid']], neighbors: DEFAULT_NEIGHBORS }),
-          queryFn: async ({ queryKey: [, body] }) => api.query(body),
-        });
-
-        if (!fullRecord) {
-          setDetailPanelRow(null);
-        } else {
-          setDetailPanelRow(fullRecord);
-        }
-      } catch (err) {
-        console.error(err);
-        handleError(err);
-      }
+      setDetailPanelRid(detailData['@rid']);
     }
-  }, [handleError, queryClient]);
+  }, []);
 
   const handleGraphStateSaveIntoURL = useCallback((nodeRIDs) => {
     navigateToGraph(nodeRIDs, navigate, snackbar);
@@ -93,7 +84,7 @@ const GraphView = () => {
 
   const edges = schema.getEdges();
   const expandedEdgeTypes = util.expandEdges(edges);
-
+  const detailPanelRow = detailsQuery.isEnabled ? detailsQuery.data : null;
   const detailPanelIsOpen = Boolean(detailPanelRow);
 
   const handleExpandRecord = async (recordId: string) => {
@@ -114,20 +105,20 @@ const GraphView = () => {
       className={`data-view ${detailPanelIsOpen ? 'data-view--squished' : ''}`}
     >
       <div className="data-view__content--graph-view">
-        {graphData && (
+        {graphQuery.data && (
           <>
             <GraphComponent
-              data={graphData}
+              data={graphQuery.data}
               detail={detailPanelRow}
               edgeTypes={expandedEdgeTypes}
               getRecord={handleExpandRecord}
               handleDetailDrawerClose={handleToggleDetailPanel}
               handleDetailDrawerOpen={handleToggleDetailPanel}
-              handleError={handleError}
               handleGraphStateSave={handleGraphStateSaveIntoURL}
             />
             {detailPanelRow && (
               <DetailDrawer
+                error={<ErrorMessage error={detailsQuery.error}>An error occurred loading details.</ErrorMessage>}
                 node={detailPanelRow}
                 onClose={handleToggleDetailPanel}
               />

--- a/src/views/GraphView/index.tsx
+++ b/src/views/GraphView/index.tsx
@@ -3,6 +3,7 @@ import './index.scss';
 import {
   CircularProgress,
 } from '@mui/material';
+import { useSnackbar } from 'notistack';
 import React, {
   useCallback, useEffect, useMemo, useState,
 } from 'react';
@@ -34,6 +35,7 @@ const GraphView = () => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const recordIds = useMemo(() => getNodeRIDsFromURL(`${window.location.origin}${search}`), []);
   const queryClient = useQueryClient();
+  const snackbar = useSnackbar();
 
   const handleError = useCallback((err) => {
     util.handleErrorSaveLocation(err, { navigate, pathname: '/data/table', search });
@@ -86,8 +88,8 @@ const GraphView = () => {
   }, [handleError, queryClient]);
 
   const handleGraphStateSaveIntoURL = useCallback((nodeRIDs) => {
-    navigateToGraph(nodeRIDs, navigate, handleError);
-  }, [handleError, navigate]);
+    navigateToGraph(nodeRIDs, navigate, snackbar);
+  }, [snackbar, navigate]);
 
   const edges = schema.getEdges();
   const expandedEdgeTypes = util.expandEdges(edges);

--- a/src/views/GraphView/index.tsx
+++ b/src/views/GraphView/index.tsx
@@ -30,8 +30,9 @@ const GraphView = () => {
   const navigate = useNavigate();
   const isLoading = useIsFetching();
   const [detailPanelRow, setDetailPanelRow] = useState<GeneralRecordType | null>(null);
-  // the existing behaviour of the graph relies on this not changing even when the url *is* updated
-  const recordIds = useMemo(() => getNodeRIDsFromURL(window.location.href), []);
+  // the existing behaviour of the graph relies on this not changing even when the url *is* updated (TODO fix logic so this can update)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const recordIds = useMemo(() => getNodeRIDsFromURL(`${window.location.origin}${search}`), []);
   const queryClient = useQueryClient();
 
   const handleError = useCallback((err) => {

--- a/src/views/ImportPubmedView/index.tsx
+++ b/src/views/ImportPubmedView/index.tsx
@@ -6,22 +6,18 @@ import {
 } from '@mui/material';
 import { titleCase } from 'change-case';
 import { useSnackbar } from 'notistack';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useMutation, useQuery } from 'react-query';
-import { useLocation, useNavigate, useSearchParams } from 'react-router';
 import { useDebounce } from 'use-debounce';
 
 import { tuple } from '@/components/util';
-import util from '@/services/util';
+import { ErrorMessage } from '@/services/errors';
 
 import SearchBox from '../../components/SearchBox';
 import api from '../../services/api';
 import PubmedCard from './components/PubmedCard';
 
 const ImportPubmedView = () => {
-  const navigate = useNavigate();
-  const { pathname } = useLocation();
-  const [searchParams] = useSearchParams();
   const snackbar = useSnackbar();
   const [errorText, setErrorText] = useState('');
   const [text, setText] = useState('');
@@ -59,16 +55,6 @@ const ImportPubmedView = () => {
     enabled: Boolean(text),
   });
 
-  useEffect(() => {
-    if (error || sourceError) {
-      util.handleErrorSaveLocation(error || sourceError, {
-        navigate,
-        pathname,
-        search: searchParams.toString(),
-      });
-    }
-  }, [error, navigate, pathname, searchParams, sourceError]);
-
   // fetch details from PUBMED
   const { data: externalRecord = null } = useQuery({
     queryKey: [`/extensions/pubmed/${pmid}`],
@@ -76,20 +62,12 @@ const ImportPubmedView = () => {
     enabled: Boolean(pmid),
   });
 
-  const { mutate: importRecord, isPending: isImporting } = useMutation({
+  const { mutate: importRecord, isPending: isImporting, error: importError } = useMutation({
     mutationFn: async () => {
       if (externalRecord) {
-        try {
-          const result = await api.post('/publications', { ...externalRecord, source });
-          snackbar.enqueueSnackbar(`created the new publication record ${result['@rid']}`, { variant: 'success' });
-          refetchCurrentRecords();
-        } catch (err) {
-          util.handleErrorSaveLocation(err, {
-            navigate,
-            pathname,
-            search: searchParams.toString(),
-          });
-        }
+        const result = await api.post('/publications', { ...externalRecord, source });
+        snackbar.enqueueSnackbar(`created the new publication record ${result['@rid']}`, { variant: 'success' });
+        refetchCurrentRecords();
       }
     },
   });
@@ -128,6 +106,8 @@ const ImportPubmedView = () => {
           title={titleCase(rec.name as string)}
         />
       ))}
+      <ErrorMessage error={error || sourceError}>An error occurred loading records.</ErrorMessage>
+      <ErrorMessage error={importError}>An error occurred importing records.</ErrorMessage>
       {(isImporting || isLoading) && <CircularProgress className="import-view__progress" />}
       {(!currentRecords || !currentRecords.length) && externalRecord && (
         <PubmedCard

--- a/src/views/MainView/index.tsx
+++ b/src/views/MainView/index.tsx
@@ -12,6 +12,7 @@ import { Navigate, Route, Routes } from 'react-router';
 
 import { AuthenticatedLayout } from '@/components/Auth';
 import { FORM_VARIANT } from '@/components/util';
+import ErrorBoundary from '@/views/ErrorView';
 
 import MainAppBar from './components/MainAppBar';
 import MainNav from './components/MainNav';
@@ -28,7 +29,6 @@ const AdminView = lazy(() => import('@/views/AdminView'));
 const AdvancedSearchView = lazy(() => import('@/views/AdvancedSearchView'));
 const DataView = lazy(() => import('@/views/DataView'));
 const GraphView = lazy(() => import('@/views/GraphView'));
-const ErrorView = lazy(() => import('@/views/ErrorView'));
 const FeedbackView = lazy(() => import('@/views/FeedbackView'));
 const ImportPubmedView = lazy(() => import('@/views/ImportPubmedView'));
 const NewRecordView = lazy(() => import('@/views/NewRecordView'));
@@ -44,7 +44,6 @@ const ABSTRACT_CLASSES = Object.values(schemaDefn.models)
 export function AppRoutes() {
   return (
     <Routes>
-      <Route element={<ErrorView />} path="/error" />
       <Route element={<AuthenticatedLayout />}>
         <Route Component={FeedbackView} path="/feedback" />
         <Route Component={AboutView} path="/about">
@@ -109,9 +108,11 @@ const Main = () => {
         onDrawerChange={setDrawerOpen}
       />
       <section className={`main-view__content ${drawerOpen ? 'main-view__content--drawer-open' : ''}`}>
-        <Suspense fallback={(<CircularProgress color="secondary" />)}>
-          <AppRoutes />
-        </Suspense>
+        <ErrorBoundary>
+          <Suspense fallback={(<CircularProgress color="secondary" />)}>
+            <AppRoutes />
+          </Suspense>
+        </ErrorBoundary>
       </section>
     </div>
   );

--- a/src/views/NewRecordView/__snapshots__/index.stories.tsx.snap
+++ b/src/views/NewRecordView/__snapshots__/index.stories.tsx.snap
@@ -1618,6 +1618,59 @@ exports[`NewRelationshipAliasOf snapshot 1`] = `
 </div>
 `;
 
+exports[`NewRelationshipAliasOfErrorAfterSubmit snapshot 1`] = `
+<div>
+  <div
+  >
+    <div
+      class="error-wrapper"
+    >
+      <h2
+        class="MuiTypography-h2 MuiTypography-root css-XXXX-MuiTypography-root"
+      >
+        Error
+      </h2>
+      <h3
+        class="MuiTypography-h3 MuiTypography-root css-XXXX-MuiTypography-root"
+      >
+        Unexpected Error [500]: Internal Server Error
+      </h3>
+      <p
+        class="MuiTypography-body1 MuiTypography-paragraph MuiTypography-root css-XXXX-MuiTypography-root"
+      >
+        Report this error in a
+        <a
+          href="https://www.bcgsc.ca/jira/projects/KBDEV"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Ticket/Issue
+        </a>
+         ticket or email us at 
+        <a
+          href="mailto:graphkb@bcgsc.ca?subject=Error%3A%20Unexpected%20Error%20%5B500%5D%3A%20Internal%20Server%20Error&body=Error%20Details%20(Please%20include%20in%20error%20reports)%0Aversion%3A%204.4.1%0Aerror%20name%3A%20Error%0Aerror%20text%3A%20Unexpected%20Error%20%5B500%5D%3A%20Internal%20Server%20Error"
+        >
+          graphkb@bcgsc.ca
+        </a>
+        .
+      </p>
+      <a
+        data-discover="true"
+        href="/"
+      >
+        <button
+          class="MuiButton-colorPrimary MuiButton-contained MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-root MuiButton-sizeSmall MuiButtonBase-root css-XXXX-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          Home
+        </button>
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`NewSource snapshot 1`] = `
 <div>
   <div

--- a/src/views/NewRecordView/__snapshots__/index.stories.tsx.snap
+++ b/src/views/NewRecordView/__snapshots__/index.stories.tsx.snap
@@ -1,5 +1,58 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`NewInvalidModel snapshot 1`] = `
+<div>
+  <div
+  >
+    <div
+      class="error-wrapper"
+    >
+      <h2
+        class="MuiTypography-h2 MuiTypography-root css-XXXX-MuiTypography-root"
+      >
+        ValidationError
+      </h2>
+      <h3
+        class="MuiTypography-h3 MuiTypography-root css-XXXX-MuiTypography-root"
+      >
+        Unable to retrieve model: blargh
+      </h3>
+      <p
+        class="MuiTypography-body1 MuiTypography-paragraph MuiTypography-root css-XXXX-MuiTypography-root"
+      >
+        Report this error in a
+        <a
+          href="https://www.bcgsc.ca/jira/projects/KBDEV"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Ticket/Issue
+        </a>
+         ticket or email us at 
+        <a
+          href="mailto:graphkb@bcgsc.ca?subject=ValidationError%3A%20Unable%20to%20retrieve%20model%3A%20blargh&body=Error%20Details%20(Please%20include%20in%20error%20reports)%0Aversion%3A%204.4.1%0Aerror%20name%3A%20ValidationError%0Aerror%20text%3A%20Unable%20to%20retrieve%20model%3A%20blargh"
+        >
+          graphkb@bcgsc.ca
+        </a>
+        .
+      </p>
+      <a
+        data-discover="true"
+        href="/"
+      >
+        <button
+          class="MuiButton-colorPrimary MuiButton-contained MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-root MuiButton-sizeSmall MuiButtonBase-root css-XXXX-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          Home
+        </button>
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`NewOntology snapshot 1`] = `
 <div>
   <div
@@ -1623,49 +1676,570 @@ exports[`NewRelationshipAliasOfErrorAfterSubmit snapshot 1`] = `
   <div
   >
     <div
-      class="error-wrapper"
+      class="new-record-view"
     >
-      <h2
-        class="MuiTypography-h2 MuiTypography-root css-XXXX-MuiTypography-root"
+      <div
+        class="MuiPaper-elevation MuiPaper-elevation4 MuiPaper-root MuiPaper-rounded css-XXXX-MuiPaper-root record-form__wrapper"
       >
-        Error
-      </h2>
-      <h3
-        class="MuiTypography-h3 MuiTypography-root css-XXXX-MuiTypography-root"
-      >
-        Unexpected Error [500]: Internal Server Error
-      </h3>
-      <p
-        class="MuiTypography-body1 MuiTypography-paragraph MuiTypography-root css-XXXX-MuiTypography-root"
-      >
-        Report this error in a
-        <a
-          href="https://www.bcgsc.ca/jira/projects/KBDEV"
-          rel="noopener noreferrer"
-          target="_blank"
+        <div
+          class="record-form__header"
         >
-          Ticket/Issue
-        </a>
-         ticket or email us at 
-        <a
-          href="mailto:graphkb@bcgsc.ca?subject=Error%3A%20Unexpected%20Error%20%5B500%5D%3A%20Internal%20Server%20Error&body=Error%20Details%20(Please%20include%20in%20error%20reports)%0Aversion%3A%204.4.1%0Aerror%20name%3A%20Error%0Aerror%20text%3A%20Unexpected%20Error%20%5B500%5D%3A%20Internal%20Server%20Error"
+          <span
+            class="title"
+          >
+            <h1
+              class="MuiTypography-h1 MuiTypography-root css-XXXX-MuiTypography-root"
+            >
+              Create a new AliasOf Record
+            </h1>
+          </span>
+          <div
+            class="header__actions header__actions--new"
+          />
+        </div>
+        <div
+          class="form-layout"
         >
-          graphkb@bcgsc.ca
-        </a>
-        .
-      </p>
-      <a
-        data-discover="true"
-        href="/"
-      >
-        <button
-          class="MuiButton-colorPrimary MuiButton-contained MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-root MuiButton-sizeSmall MuiButtonBase-root css-XXXX-MuiButtonBase-root-MuiButton-root"
-          tabindex="0"
-          type="button"
+          <div
+            class="form-layout__content form-layout__content--long"
+          >
+            <p
+              class="MuiTypography-body1 MuiTypography-root css-XXXX-MuiTypography-root sentence-preview"
+            >
+              <span
+                class="sentence-preview__chunk"
+              >
+                 is a Alias Of
+              </span>
+            </p>
+          </div>
+          <ul
+            class="MuiList-padding MuiList-root css-XXXX-MuiList-root form-layout__content"
+          >
+            <li
+              class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root form-field form-field--link"
+            >
+              <div
+                class="MuiFormControl-root css-XXXX-MuiFormControl-root filtered-record-autocomplete"
+              >
+                <div
+                  class="filtered-record-autocomplete__content"
+                >
+                  <div
+                    class="MuiFormControl-root css-XXXX-MuiFormControl-root filtered-record-autocomplete__select-search-class node-form__class-select option-select"
+                  >
+                    <label
+                      class="MuiFormLabel-colorPrimary MuiFormLabel-filled MuiFormLabel-root MuiInputLabel-animated MuiInputLabel-formControl MuiInputLabel-root MuiInputLabel-shrink MuiInputLabel-standard css-XXXX-MuiFormLabel-root-MuiInputLabel-root"
+                      data-shrink="true"
+                      for="option-select-search-class"
+                    >
+                      Filter (out) Search by Class
+                    </label>
+                    <div
+                      class="MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-root MuiSelect-root css-XXXX-MuiInputBase-root-MuiInput-root"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        aria-labelledby="mui-component-select-search-class"
+                        class="MuiInput-input MuiInputBase-input MuiSelect-select MuiSelect-standard css-XXXX-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                        id="mui-component-select-search-class"
+                        role="combobox"
+                        tabindex="0"
+                      >
+                        <div
+                          class="MuiListItemText-dense MuiListItemText-root css-XXXX-MuiListItemText-root"
+                        >
+                          <span
+                            class="MuiListItemText-primary MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root"
+                          >
+                            Ontology
+                          </span>
+                          <p
+                            class="MuiListItemText-secondary MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root option-select__option-description"
+                          />
+                        </div>
+                      </div>
+                      <input
+                        aria-hidden="true"
+                        aria-invalid="false"
+                        class="MuiSelect-nativeInput css-XXXX-MuiSelect-nativeInput"
+                        id="option-select-search-class"
+                        name="search-class"
+                        tabindex="-1"
+                        value="Ontology"
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSelect-icon MuiSelect-iconStandard MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
+                        data-testid="FilterListIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
+                        />
+                      </svg>
+                    </div>
+                    <p
+                      class="MuiFormHelperText-filled MuiFormHelperText-root MuiFormHelperText-sizeMedium css-XXXX-MuiFormHelperText-root"
+                    />
+                  </div>
+                  <div
+                    class="MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon MuiAutocomplete-root css-XXXX-MuiAutocomplete-root record-autocomplete"
+                  >
+                    <div
+                      class="MuiFormControl-fullWidth MuiFormControl-root MuiTextField-root css-XXXX-MuiFormControl-root-MuiTextField-root"
+                    >
+                      <label
+                        class="Mui-required MuiFormLabel-colorPrimary MuiFormLabel-root MuiInputLabel-animated MuiInputLabel-formControl MuiInputLabel-root MuiInputLabel-shrink MuiInputLabel-standard css-XXXX-MuiFormLabel-root-MuiInputLabel-root"
+                        data-shrink="true"
+                        for="_r_XXXX_"
+                        id="_r_XXXX_-label"
+                      >
+                        Source Record (out)
+                        <span
+                          aria-hidden="true"
+                          class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-XXXX-MuiFormLabel-asterisk"
+                        >
+                           
+                          *
+                        </span>
+                      </label>
+                      <div
+                        class="MuiAutocomplete-inputRoot MuiInput-root MuiInputBase-adornedEnd MuiInputBase-adornedStart MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-fullWidth MuiInputBase-root css-XXXX-MuiInputBase-root-MuiInput-root"
+                      >
+                        <div
+                          class="detail-chip"
+                        >
+                          <div
+                            class="MuiAutocomplete-tag MuiAutocomplete-tagSizeMedium MuiButtonBase-root MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-colorPrimary MuiChip-deletable MuiChip-deletableColorPrimary MuiChip-outlined MuiChip-outlinedPrimary MuiChip-root MuiChip-sizeSmall css-XXXX-MuiButtonBase-root-MuiChip-root detail-chip__outlined detail-chip__root record-autocomplete__chip record-autocomplete__chip--multi"
+                            data-item-index="0"
+                            role="button"
+                            tabindex="-1"
+                          >
+                            <span
+                              class="MuiChip-label MuiChip-labelSmall css-XXXX-MuiChip-label"
+                            >
+                              Ontology (111:111)
+                            </span>
+                            <svg
+                              aria-hidden="true"
+                              class="MuiChip-deleteIcon MuiChip-deleteIconColorPrimary MuiChip-deleteIconOutlinedColorPrimary MuiChip-deleteIconSmall MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                              data-testid="CancelIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <input
+                          aria-autocomplete="list"
+                          aria-expanded="false"
+                          aria-invalid="false"
+                          autocapitalize="none"
+                          autocomplete="off"
+                          class="MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd MuiInputBase-inputAdornedStart css-XXXX-MuiInputBase-input-MuiInput-input"
+                          id="_r_XXXX_"
+                          placeholder=""
+                          required=""
+                          role="combobox"
+                          spellcheck="false"
+                          type="text"
+                          value=""
+                        />
+                        <div
+                          class="MuiAutocomplete-endAdornment css-XXXX-MuiAutocomplete-endAdornment"
+                        >
+                          <button
+                            aria-label="Clear"
+                            class="MuiAutocomplete-clearIndicator MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-clearIndicator"
+                            tabindex="-1"
+                            title="Clear"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                              data-testid="CloseIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                              />
+                            </svg>
+                          </button>
+                          <button
+                            aria-label="Open"
+                            class="MuiAutocomplete-popupIndicator MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                            tabindex="-1"
+                            title="Open"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                              data-testid="SearchIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <p
+                  class="MuiFormHelperText-contained MuiFormHelperText-root MuiFormHelperText-sizeMedium css-XXXX-MuiFormHelperText-root"
+                >
+                  The source record for the relationship
+                </p>
+              </div>
+            </li>
+            <li
+              class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root form-field form-field--link"
+            >
+              <div
+                class="MuiFormControl-root css-XXXX-MuiFormControl-root filtered-record-autocomplete"
+              >
+                <div
+                  class="filtered-record-autocomplete__content"
+                >
+                  <div
+                    class="MuiFormControl-root css-XXXX-MuiFormControl-root filtered-record-autocomplete__select-search-class node-form__class-select option-select"
+                  >
+                    <label
+                      class="MuiFormLabel-colorPrimary MuiFormLabel-filled MuiFormLabel-root MuiInputLabel-animated MuiInputLabel-formControl MuiInputLabel-root MuiInputLabel-shrink MuiInputLabel-standard css-XXXX-MuiFormLabel-root-MuiInputLabel-root"
+                      data-shrink="true"
+                      for="option-select-search-class"
+                    >
+                      Filter (in) Search by Class
+                    </label>
+                    <div
+                      class="MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-root MuiSelect-root css-XXXX-MuiInputBase-root-MuiInput-root"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        aria-labelledby="mui-component-select-search-class"
+                        class="MuiInput-input MuiInputBase-input MuiSelect-select MuiSelect-standard css-XXXX-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                        id="mui-component-select-search-class"
+                        role="combobox"
+                        tabindex="0"
+                      >
+                        <div
+                          class="MuiListItemText-dense MuiListItemText-root css-XXXX-MuiListItemText-root"
+                        >
+                          <span
+                            class="MuiListItemText-primary MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root"
+                          >
+                            Ontology
+                          </span>
+                          <p
+                            class="MuiListItemText-secondary MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root option-select__option-description"
+                          />
+                        </div>
+                      </div>
+                      <input
+                        aria-hidden="true"
+                        aria-invalid="false"
+                        class="MuiSelect-nativeInput css-XXXX-MuiSelect-nativeInput"
+                        id="option-select-search-class"
+                        name="search-class"
+                        tabindex="-1"
+                        value="Ontology"
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSelect-icon MuiSelect-iconStandard MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
+                        data-testid="FilterListIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
+                        />
+                      </svg>
+                    </div>
+                    <p
+                      class="MuiFormHelperText-filled MuiFormHelperText-root MuiFormHelperText-sizeMedium css-XXXX-MuiFormHelperText-root"
+                    />
+                  </div>
+                  <div
+                    class="MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon MuiAutocomplete-root css-XXXX-MuiAutocomplete-root record-autocomplete"
+                  >
+                    <div
+                      class="MuiFormControl-fullWidth MuiFormControl-root MuiTextField-root css-XXXX-MuiFormControl-root-MuiTextField-root"
+                    >
+                      <label
+                        class="Mui-required MuiFormLabel-colorPrimary MuiFormLabel-root MuiInputLabel-animated MuiInputLabel-formControl MuiInputLabel-root MuiInputLabel-shrink MuiInputLabel-standard css-XXXX-MuiFormLabel-root-MuiInputLabel-root"
+                        data-shrink="true"
+                        for="_r_XXXX_"
+                        id="_r_XXXX_-label"
+                      >
+                        Target Record (in)
+                        <span
+                          aria-hidden="true"
+                          class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-XXXX-MuiFormLabel-asterisk"
+                        >
+                           
+                          *
+                        </span>
+                      </label>
+                      <div
+                        class="MuiAutocomplete-inputRoot MuiInput-root MuiInputBase-adornedEnd MuiInputBase-adornedStart MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-fullWidth MuiInputBase-root css-XXXX-MuiInputBase-root-MuiInput-root"
+                      >
+                        <div
+                          class="detail-chip"
+                        >
+                          <div
+                            class="MuiAutocomplete-tag MuiAutocomplete-tagSizeMedium MuiButtonBase-root MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-colorPrimary MuiChip-deletable MuiChip-deletableColorPrimary MuiChip-outlined MuiChip-outlinedPrimary MuiChip-root MuiChip-sizeSmall css-XXXX-MuiButtonBase-root-MuiChip-root detail-chip__outlined detail-chip__root record-autocomplete__chip record-autocomplete__chip--multi"
+                            data-item-index="0"
+                            role="button"
+                            tabindex="-1"
+                          >
+                            <span
+                              class="MuiChip-label MuiChip-labelSmall css-XXXX-MuiChip-label"
+                            >
+                              Ontology (222:222)
+                            </span>
+                            <svg
+                              aria-hidden="true"
+                              class="MuiChip-deleteIcon MuiChip-deleteIconColorPrimary MuiChip-deleteIconOutlinedColorPrimary MuiChip-deleteIconSmall MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                              data-testid="CancelIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <input
+                          aria-autocomplete="list"
+                          aria-expanded="false"
+                          aria-invalid="false"
+                          autocapitalize="none"
+                          autocomplete="off"
+                          class="MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd MuiInputBase-inputAdornedStart css-XXXX-MuiInputBase-input-MuiInput-input"
+                          id="_r_XXXX_"
+                          placeholder=""
+                          required=""
+                          role="combobox"
+                          spellcheck="false"
+                          type="text"
+                          value=""
+                        />
+                        <div
+                          class="MuiAutocomplete-endAdornment css-XXXX-MuiAutocomplete-endAdornment"
+                        >
+                          <button
+                            aria-label="Clear"
+                            class="MuiAutocomplete-clearIndicator MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-clearIndicator"
+                            tabindex="-1"
+                            title="Clear"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                              data-testid="CloseIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                              />
+                            </svg>
+                          </button>
+                          <button
+                            aria-label="Open"
+                            class="MuiAutocomplete-popupIndicator MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                            tabindex="-1"
+                            title="Open"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                              data-testid="SearchIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <p
+                  class="MuiFormHelperText-contained MuiFormHelperText-root MuiFormHelperText-sizeMedium css-XXXX-MuiFormHelperText-root"
+                >
+                  The target record for the relationship
+                </p>
+              </div>
+            </li>
+            <li
+              class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root form-field form-field--link"
+            >
+              <div
+                class="MuiAutocomplete-hasPopupIcon MuiAutocomplete-root css-XXXX-MuiAutocomplete-root record-autocomplete"
+              >
+                <div
+                  class="MuiFormControl-fullWidth MuiFormControl-root MuiTextField-root css-XXXX-MuiFormControl-root-MuiTextField-root"
+                >
+                  <label
+                    class="MuiFormLabel-colorPrimary MuiFormLabel-root MuiInputLabel-animated MuiInputLabel-formControl MuiInputLabel-root MuiInputLabel-shrink MuiInputLabel-standard css-XXXX-MuiFormLabel-root-MuiInputLabel-root"
+                    data-shrink="true"
+                    for="_r_XXXX_"
+                    id="_r_XXXX_-label"
+                  >
+                    source
+                  </label>
+                  <div
+                    class="MuiAutocomplete-inputRoot MuiInput-root MuiInput-underline MuiInputBase-adornedEnd MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-fullWidth MuiInputBase-root css-XXXX-MuiInputBase-root-MuiInput-root"
+                  >
+                    <input
+                      aria-autocomplete="list"
+                      aria-expanded="false"
+                      aria-invalid="false"
+                      autocapitalize="none"
+                      autocomplete="off"
+                      class="MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd css-XXXX-MuiInputBase-input-MuiInput-input"
+                      id="_r_XXXX_"
+                      placeholder="Search Records by Name or ID"
+                      role="combobox"
+                      spellcheck="false"
+                      type="text"
+                      value=""
+                    />
+                    <div
+                      class="MuiAutocomplete-endAdornment css-XXXX-MuiAutocomplete-endAdornment"
+                    >
+                      <button
+                        aria-label="Open"
+                        class="MuiAutocomplete-popupIndicator MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                        tabindex="-1"
+                        title="Open"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                          data-testid="SearchIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </li>
+          </ul>
+          <li
+            class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root"
+          >
+            <div
+              class="MuiListItemText-dense MuiListItemText-root css-XXXX-MuiListItemText-root"
+            >
+              <span
+                class="MuiListItemText-primary MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root"
+              >
+                Expand to see all optional fields
+              </span>
+            </div>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+              data-testid="ExpandMoreIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+              />
+            </svg>
+          </li>
+        </div>
+        <div
+          class="MuiAlert-colorError MuiAlert-root MuiAlert-standard MuiAlert-standardError MuiPaper-elevation MuiPaper-elevation0 MuiPaper-root MuiPaper-rounded css-XXXX-MuiPaper-root-MuiAlert-root"
+          role="alert"
         >
-          Home
-        </button>
-      </a>
+          <div
+            class="MuiAlert-icon css-XXXX-MuiAlert-icon"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-fontSizeInherit MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+              data-testid="ErrorOutlineIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiAlert-message css-XXXX-MuiAlert-message"
+          >
+            An error occurred while creating record.
+            Unexpected Error [500]: Internal Server Error
+            Report this error in a
+            <a
+              href="https://www.bcgsc.ca/jira/projects/KBDEV"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Ticket/Issue
+            </a>
+             ticket or email us at 
+            <a
+              href="mailto:graphkb@bcgsc.ca?subject=Error%3A%20Unexpected%20Error%20%5B500%5D%3A%20Internal%20Server%20Error&body=Error%20Details%20(Please%20include%20in%20error%20reports)%0Aversion%3A%204.4.1%0Aerror%20name%3A%20Error%0Aerror%20text%3A%20Unexpected%20Error%20%5B500%5D%3A%20Internal%20Server%20Error"
+            >
+              graphkb@bcgsc.ca
+            </a>
+            .
+          </div>
+        </div>
+        <div
+          class="record-form__action-buttons"
+        >
+          <div />
+          <div
+            class="action-button"
+          >
+            <button
+              class="MuiButton-colorPrimary MuiButton-contained MuiButton-containedPrimary MuiButton-containedSizeLarge MuiButton-root MuiButton-sizeLarge MuiButtonBase-root action-button__button css-XXXX-MuiButtonBase-root-MuiButton-root"
+              tabindex="0"
+              type="button"
+            >
+              SUBMIT
+              <span
+                class="MuiTouchRipple-root css-XXXX-MuiTouchRipple-root"
+              />
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -4581,7 +5155,7 @@ exports[`NewVariant snapshot 1`] = `
         </div>
         <div
           class="stepped-form__actions"
-          index="6"
+          index="7"
         >
           <div
             class="action-button stepped-form__actions--primary"

--- a/src/views/NewRecordView/index.stories.tsx
+++ b/src/views/NewRecordView/index.stories.tsx
@@ -1,7 +1,5 @@
 import { HttpResponse } from 'msw';
-import {
-  expect, screen, waitFor, waitForElementToBeRemoved,
-} from 'storybook/test';
+import { expect, screen, waitFor } from 'storybook/test';
 
 import preview, {
   hasFinishedLoading,
@@ -87,8 +85,12 @@ export const NewRelationshipAliasOfErrorAfterSubmit = meta.story({
     await userEvent.type(canvas.getByLabelText(/target record \(in\)/i), '222');
     await userEvent.click(await screen.findByText('Ontology (222:222)'));
     await userEvent.click(canvas.getByText(/submit/i));
-    const snackbar = await canvas.findByText(/Error \(Error\) in creating the record/);
     await canvas.findByText(/Internal Server Error/, { exact: false });
-    await waitForElementToBeRemoved(snackbar, { timeout: 10000 });
+  },
+});
+
+export const NewInvalidModel = meta.story({
+  args: {
+    path: '/new/Blargh',
   },
 });

--- a/src/views/NewRecordView/index.stories.tsx
+++ b/src/views/NewRecordView/index.stories.tsx
@@ -1,7 +1,11 @@
-import { expect, waitFor } from 'storybook/test';
+import { HttpResponse } from 'msw';
+import {
+  expect, screen, waitFor, waitForElementToBeRemoved,
+} from 'storybook/test';
 
 import preview, {
   hasFinishedLoading,
+  http,
   view, ViewPreviewType,
 } from '#.storybook/preview';
 
@@ -61,5 +65,30 @@ export const NewRelationship = meta.story({
 export const NewRelationshipAliasOf = meta.story({
   args: {
     path: '/new/AliasOf',
+  },
+});
+
+export const NewRelationshipAliasOfErrorAfterSubmit = meta.story({
+  args: {
+    path: '/new/AliasOf',
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        http.gkb.query(() => [{ '@rid': '111:111', '@class': 'Ontology' }, { '@rid': '222:222', '@class': 'Ontology' }]),
+        http.gkb.post('/api/aliasof', () => HttpResponse.json({ message: 'Failed unique constraint.' }, { status: 500 })),
+      ],
+    },
+  },
+  play: async ({ canvas, step, userEvent }) => {
+    await hasFinishedLoading({ canvas, step });
+    await userEvent.type(canvas.getByLabelText(/source record \(out\)/i), '111');
+    await userEvent.click(await screen.findByText('Ontology (111:111)'));
+    await userEvent.type(canvas.getByLabelText(/target record \(in\)/i), '222');
+    await userEvent.click(await screen.findByText('Ontology (222:222)'));
+    await userEvent.click(canvas.getByText(/submit/i));
+    const snackbar = await canvas.findByText(/Error \(Error\) in creating the record/);
+    await canvas.findByText(/Internal Server Error/, { exact: false });
+    await waitForElementToBeRemoved(snackbar, { timeout: 10000 });
   },
 });

--- a/src/views/NewRecordView/index.tsx
+++ b/src/views/NewRecordView/index.tsx
@@ -5,9 +5,7 @@ import React, {
   useCallback,
   useEffect,
 } from 'react';
-import {
-  useLocation, useNavigate, useParams, useSearchParams,
-} from 'react-router';
+import { useNavigate, useParams } from 'react-router';
 
 import RecordForm from '@/components/RecordForm';
 import StatementForm from '@/components/StatementForm';
@@ -15,14 +13,11 @@ import { GeneralRecordType } from '@/components/types';
 import { FORM_VARIANT } from '@/components/util';
 import NewVariant from '@/components/VariantForm';
 import schema from '@/services/schema';
-import util from '@/services/util';
 
 const VARIANT_CLASSES = ['variant', 'positionalvariant', 'categoryvariant'];
 
 const NewRecordView = ({ modelName: propsModelName }: { modelName?: string }) => {
   const navigate = useNavigate();
-  const { pathname } = useLocation();
-  const [searchParams] = useSearchParams();
   const { modelName: paramsModelName } = useParams<{ modelName: string }>();
   const modelName = propsModelName || paramsModelName;
 
@@ -36,15 +31,6 @@ const NewRecordView = ({ modelName: propsModelName }: { modelName?: string }) =>
       navigate('/');
     }
   }, [navigate]);
-
-  /**
-   * Handles the redirect if an error occurs in the child component
-   */
-  const handleError = useCallback(({ error = {} }: { error: { name?: string; message?: string } }) => {
-    const { name } = error;
-    const massagedMsg = util.massageRecordExistsError(error);
-    util.handleErrorSaveLocation({ name, message: massagedMsg }, { navigate, pathname, search: searchParams.toString() });
-  }, [navigate, pathname, searchParams]);
 
   let innerComponent: ReactNode = null;
 
@@ -62,14 +48,12 @@ const NewRecordView = ({ modelName: propsModelName }: { modelName?: string }) =>
   ) {
     innerComponent = (
       <NewVariant
-        onError={handleError}
         onSubmit={handleSubmit}
       />
     );
   } else if (modelName.toLowerCase() === 'statement') {
     innerComponent = (
       <StatementForm
-        onError={handleError}
         onSubmit={handleSubmit}
         title="Create a new Statement Record"
         variant={FORM_VARIANT.NEW}
@@ -79,7 +63,6 @@ const NewRecordView = ({ modelName: propsModelName }: { modelName?: string }) =>
     innerComponent = (
       <RecordForm
         modelName={modelName}
-        onError={handleError}
         onSubmit={handleSubmit}
         title={`Create a new ${modelName} Record`}
         variant={FORM_VARIANT.NEW}

--- a/src/views/RecordView/__snapshots__/index.stories.tsx.snap
+++ b/src/views/RecordView/__snapshots__/index.stories.tsx.snap
@@ -1078,7 +1078,7 @@ exports[`EditCategoryVariant snapshot 1`] = `
         </div>
         <div
           class="stepped-form__actions"
-          index="4"
+          index="5"
         >
           <div
             class="action-button stepped-form__actions--secondary"
@@ -2524,49 +2524,1449 @@ exports[`EditStatementErrorDeleting snapshot 1`] = `
   <div
   >
     <div
-      class="error-wrapper"
+      class="MuiPaper-elevation MuiPaper-elevation4 MuiPaper-root MuiPaper-rounded css-XXXX-MuiPaper-root statement-form__wrapper"
     >
-      <h2
-        class="MuiTypography-h2 MuiTypography-root css-XXXX-MuiTypography-root"
+      <div
+        class="statement-form__header"
       >
-        AuthorizationError
-      </h2>
-      <h3
-        class="MuiTypography-h3 MuiTypography-root css-XXXX-MuiTypography-root"
-      >
-        Insufficient permissions to delete record.
-      </h3>
-      <p
-        class="MuiTypography-body1 MuiTypography-paragraph MuiTypography-root css-XXXX-MuiTypography-root"
-      >
-        Report this error in a
-        <a
-          href="https://www.bcgsc.ca/jira/projects/KBDEV"
-          rel="noopener noreferrer"
-          target="_blank"
+        <span
+          class="title"
         >
-          Ticket/Issue
-        </a>
-         ticket or email us at 
-        <a
-          href="mailto:graphkb@bcgsc.ca?subject=AuthorizationError%3A%20Insufficient%20permissions%20to%20delete%20record.&body=Error%20Details%20(Please%20include%20in%20error%20reports)%0Aversion%3A%204.4.1%0Aerror%20name%3A%20AuthorizationError%0Aerror%20text%3A%20Insufficient%20permissions%20to%20delete%20record."
+          <h1
+            class="MuiTypography-h1 MuiTypography-root css-XXXX-MuiTypography-root"
+          >
+            Edit this Record
+          </h1>
+        </span>
+        <div
+          class="header__actions header__actions--edit"
         >
-          graphkb@bcgsc.ca
-        </a>
-        .
-      </p>
-      <a
-        data-discover="true"
-        href="/"
+          <button
+            class="MuiButton-colorPrimary MuiButton-outlined MuiButton-outlinedPrimary MuiButton-outlinedSizeSmall MuiButton-root MuiButton-sizeSmall MuiButtonBase-root css-XXXX-MuiButtonBase-root-MuiButton-root header__review-action"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root review-icon"
+              data-testid="LocalLibraryIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 11.55C9.64 9.35 6.48 8 3 8v11c3.48 0 6.64 1.35 9 3.55 2.36-2.19 5.52-3.55 9-3.55V8c-3.48 0-6.64 1.35-9 3.55M12 8c1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3 1.34 3 3 3"
+              />
+            </svg>
+            Add Review
+          </button>
+          <div
+            aria-label="form state toggle"
+            class="MuiToggleButtonGroup-horizontal MuiToggleButtonGroup-root css-XXXX-MuiToggleButtonGroup-root record-form-state-toggle"
+            role="group"
+          >
+            <button
+              aria-label="graph"
+              aria-pressed="false"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-firstButton MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal css-XXXX-MuiButtonBase-root-MuiToggleButton-root"
+              data-testid="graph-view"
+              tabindex="0"
+              type="button"
+              value="graph"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                data-testid="TimelineIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2"
+                />
+              </svg>
+              <span
+                class="toggle-option__text"
+              >
+                Graph
+              </span>
+            </button>
+            <button
+              aria-label="view"
+              aria-pressed="false"
+              class="MuiButtonBase-root MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-middleButton css-XXXX-MuiButtonBase-root-MuiToggleButton-root"
+              tabindex="0"
+              type="button"
+              value="view"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                data-testid="VisibilityIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5M12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5m0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3"
+                />
+              </svg>
+              <span
+                class="toggle-option__text"
+              >
+                View
+              </span>
+            </button>
+            <button
+              aria-label="edit"
+              aria-pressed="true"
+              class="Mui-selected MuiButtonBase-root MuiToggleButton-root MuiToggleButton-sizeSmall MuiToggleButton-standard MuiToggleButtonGroup-grouped MuiToggleButtonGroup-groupedHorizontal MuiToggleButtonGroup-lastButton css-XXXX-MuiButtonBase-root-MuiToggleButton-root"
+              tabindex="0"
+              type="button"
+              value="edit"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                data-testid="CreateIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.996.996 0 0 0-1.41 0l-1.83 1.83 3.75 3.75z"
+                />
+              </svg>
+              <span
+                class="toggle-option__text"
+              >
+                Edit
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="form-layout"
       >
-        <button
-          class="MuiButton-colorPrimary MuiButton-contained MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-root MuiButton-sizeSmall MuiButtonBase-root css-XXXX-MuiButtonBase-root-MuiButton-root"
-          tabindex="0"
-          type="button"
+        <div
+          class="form-layout__content form-layout__content--long"
         >
-          Home
-        </button>
-      </a>
+          <p
+            class="MuiTypography-body1 MuiTypography-root css-XXXX-MuiTypography-root sentence-preview"
+          >
+            <mark
+              class="sentence-preview__chunk--highlighted"
+            >
+              high mutation burden high signature
+            </mark>
+            <span
+              class="sentence-preview__chunk"
+            >
+               is associated with
+            </span>
+            <mark
+              class="sentence-preview__chunk--highlighted"
+            >
+              sensitivity
+            </mark>
+            <span
+              class="sentence-preview__chunk"
+            >
+               to
+            </span>
+            <mark
+              class="sentence-preview__chunk--highlighted"
+            >
+              pembrolizumab [DB09037]
+            </mark>
+            <span
+              class="sentence-preview__chunk"
+            >
+               in
+            </span>
+            <mark
+              class="sentence-preview__chunk--highlighted"
+            >
+              all solid tumors
+            </mark>
+            <span
+              class="sentence-preview__chunk"
+            >
+               (
+            </span>
+            <mark
+              class="sentence-preview__chunk--highlighted"
+            >
+              FDA approves pembrolizumab for adults and children with TMB-H solid tumors
+            </mark>
+            <span
+              class="sentence-preview__chunk"
+            >
+              ) (
+            </span>
+            <mark
+              class="sentence-preview__chunk--highlighted"
+            >
+              IPR-A
+            </mark>
+            <span
+              class="sentence-preview__chunk"
+            >
+              )
+            </span>
+          </p>
+        </div>
+        <ul
+          class="MuiList-padding MuiList-root css-XXXX-MuiList-root form-layout__content"
+        >
+          <li
+            class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root form-field form-field--linkset"
+          >
+            <div
+              class="MuiFormControl-root css-XXXX-MuiFormControl-root filtered-record-autocomplete"
+            >
+              <div
+                class="filtered-record-autocomplete__content"
+              >
+                <div
+                  class="MuiFormControl-root css-XXXX-MuiFormControl-root filtered-record-autocomplete__select-search-class node-form__class-select option-select"
+                >
+                  <label
+                    class="MuiFormLabel-colorPrimary MuiFormLabel-filled MuiFormLabel-root MuiInputLabel-animated MuiInputLabel-formControl MuiInputLabel-root MuiInputLabel-shrink MuiInputLabel-standard css-XXXX-MuiFormLabel-root-MuiInputLabel-root"
+                    data-shrink="true"
+                    for="option-select-search-class"
+                  >
+                    Filter (conditions) Search by Class
+                  </label>
+                  <div
+                    class="MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-root MuiSelect-root css-XXXX-MuiInputBase-root-MuiInput-root"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-haspopup="listbox"
+                      aria-labelledby="mui-component-select-search-class"
+                      class="MuiInput-input MuiInputBase-input MuiSelect-select MuiSelect-standard css-XXXX-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                      id="mui-component-select-search-class"
+                      role="combobox"
+                      tabindex="0"
+                    >
+                      <div
+                        class="MuiListItemText-dense MuiListItemText-root css-XXXX-MuiListItemText-root"
+                      >
+                        <span
+                          class="MuiListItemText-primary MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root"
+                        >
+                          Variant
+                        </span>
+                        <p
+                          class="MuiListItemText-secondary MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root option-select__option-description"
+                        />
+                      </div>
+                    </div>
+                    <input
+                      aria-hidden="true"
+                      aria-invalid="false"
+                      class="MuiSelect-nativeInput css-XXXX-MuiSelect-nativeInput"
+                      id="option-select-search-class"
+                      name="search-class"
+                      tabindex="-1"
+                      value="Variant"
+                    />
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSelect-icon MuiSelect-iconStandard MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
+                      data-testid="FilterListIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
+                      />
+                    </svg>
+                  </div>
+                  <p
+                    class="MuiFormHelperText-filled MuiFormHelperText-root MuiFormHelperText-sizeMedium css-XXXX-MuiFormHelperText-root"
+                  />
+                </div>
+                <div
+                  class="MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon MuiAutocomplete-root css-XXXX-MuiAutocomplete-root record-autocomplete"
+                >
+                  <div
+                    class="MuiFormControl-fullWidth MuiFormControl-root MuiTextField-root css-XXXX-MuiFormControl-root-MuiTextField-root"
+                  >
+                    <label
+                      class="Mui-required MuiFormLabel-colorPrimary MuiFormLabel-root MuiInputLabel-animated MuiInputLabel-formControl MuiInputLabel-root MuiInputLabel-shrink MuiInputLabel-standard css-XXXX-MuiFormLabel-root-MuiInputLabel-root"
+                      data-shrink="true"
+                      for="_r_XXXX_"
+                      id="_r_XXXX_-label"
+                    >
+                      conditions
+                      <span
+                        aria-hidden="true"
+                        class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-XXXX-MuiFormLabel-asterisk"
+                      >
+                         
+                        *
+                      </span>
+                    </label>
+                    <div
+                      class="MuiAutocomplete-inputRoot MuiInput-root MuiInput-underline MuiInputBase-adornedEnd MuiInputBase-adornedStart MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-fullWidth MuiInputBase-root css-XXXX-MuiInputBase-root-MuiInput-root"
+                    >
+                      <div
+                        class="detail-chip"
+                      >
+                        <div
+                          class="MuiAutocomplete-tag MuiAutocomplete-tagSizeMedium MuiButtonBase-root MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-colorPrimary MuiChip-deletable MuiChip-deletableColorPrimary MuiChip-outlined MuiChip-outlinedPrimary MuiChip-root MuiChip-sizeSmall css-XXXX-MuiButtonBase-root-MuiChip-root detail-chip__outlined detail-chip__root record-autocomplete__chip record-autocomplete__chip--multi"
+                          data-item-index="0"
+                          role="button"
+                          tabindex="-1"
+                        >
+                          <span
+                            class="MuiChip-label MuiChip-labelSmall css-XXXX-MuiChip-label"
+                          >
+                            pembrolizumab [DB09037] (#122:30774)
+                          </span>
+                          <svg
+                            aria-hidden="true"
+                            class="MuiChip-deleteIcon MuiChip-deleteIconColorPrimary MuiChip-deleteIconOutlinedColorPrimary MuiChip-deleteIconSmall MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                            data-testid="CancelIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                      <div
+                        class="detail-chip"
+                      >
+                        <div
+                          class="MuiAutocomplete-tag MuiAutocomplete-tagSizeMedium MuiButtonBase-root MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-colorPrimary MuiChip-deletable MuiChip-deletableColorPrimary MuiChip-outlined MuiChip-outlinedPrimary MuiChip-root MuiChip-sizeSmall css-XXXX-MuiButtonBase-root-MuiChip-root detail-chip__outlined detail-chip__root record-autocomplete__chip record-autocomplete__chip--multi"
+                          data-item-index="1"
+                          role="button"
+                          tabindex="-1"
+                        >
+                          <span
+                            class="MuiChip-label MuiChip-labelSmall css-XXXX-MuiChip-label"
+                          >
+                            all solid tumors (#133:21363)
+                          </span>
+                          <svg
+                            aria-hidden="true"
+                            class="MuiChip-deleteIcon MuiChip-deleteIconColorPrimary MuiChip-deleteIconOutlinedColorPrimary MuiChip-deleteIconSmall MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                            data-testid="CancelIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                      <div
+                        class="detail-chip"
+                      >
+                        <div
+                          class="MuiAutocomplete-tag MuiAutocomplete-tagSizeMedium MuiButtonBase-root MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-colorPrimary MuiChip-deletable MuiChip-deletableColorPrimary MuiChip-outlined MuiChip-outlinedPrimary MuiChip-root MuiChip-sizeSmall css-XXXX-MuiButtonBase-root-MuiChip-root detail-chip__outlined detail-chip__root record-autocomplete__chip record-autocomplete__chip--multi"
+                          data-item-index="2"
+                          role="button"
+                          tabindex="-1"
+                        >
+                          <span
+                            class="MuiChip-label MuiChip-labelSmall css-XXXX-MuiChip-label"
+                          >
+                            high mutation burden high signature (#161:920)
+                          </span>
+                          <svg
+                            aria-hidden="true"
+                            class="MuiChip-deleteIcon MuiChip-deleteIconColorPrimary MuiChip-deleteIconOutlinedColorPrimary MuiChip-deleteIconSmall MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                            data-testid="CancelIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                      <input
+                        aria-autocomplete="list"
+                        aria-expanded="false"
+                        aria-invalid="false"
+                        autocapitalize="none"
+                        autocomplete="off"
+                        class="MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd MuiInputBase-inputAdornedStart css-XXXX-MuiInputBase-input-MuiInput-input"
+                        id="_r_XXXX_"
+                        placeholder=""
+                        required=""
+                        role="combobox"
+                        spellcheck="false"
+                        type="text"
+                        value=""
+                      />
+                      <div
+                        class="MuiAutocomplete-endAdornment css-XXXX-MuiAutocomplete-endAdornment"
+                      >
+                        <button
+                          aria-label="Clear"
+                          class="MuiAutocomplete-clearIndicator MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-clearIndicator"
+                          tabindex="-1"
+                          title="Clear"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                            data-testid="CloseIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                            />
+                          </svg>
+                        </button>
+                        <button
+                          aria-label="Open"
+                          class="MuiAutocomplete-popupIndicator MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                          tabindex="-1"
+                          title="Open"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                            data-testid="SearchIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <p
+                class="MuiFormHelperText-contained MuiFormHelperText-root MuiFormHelperText-sizeMedium css-XXXX-MuiFormHelperText-root"
+              >
+                This is the statement context. Formally it is a set of conditions which when true result in the overall assertion of the statement
+              </p>
+            </div>
+          </li>
+          <li
+            class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root form-field form-field--linkset"
+          >
+            <div
+              class="MuiFormControl-root css-XXXX-MuiFormControl-root filtered-record-autocomplete"
+            >
+              <div
+                class="filtered-record-autocomplete__content"
+              >
+                <div
+                  class="MuiFormControl-root css-XXXX-MuiFormControl-root filtered-record-autocomplete__select-search-class node-form__class-select option-select"
+                >
+                  <label
+                    class="MuiFormLabel-colorPrimary MuiFormLabel-filled MuiFormLabel-root MuiInputLabel-animated MuiInputLabel-formControl MuiInputLabel-root MuiInputLabel-shrink MuiInputLabel-standard css-XXXX-MuiFormLabel-root-MuiInputLabel-root"
+                    data-shrink="true"
+                    for="option-select-search-class"
+                  >
+                    Filter (evidence) Search by Class
+                  </label>
+                  <div
+                    class="MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-root MuiSelect-root css-XXXX-MuiInputBase-root-MuiInput-root"
+                  >
+                    <div
+                      aria-expanded="false"
+                      aria-haspopup="listbox"
+                      aria-labelledby="mui-component-select-search-class"
+                      class="MuiInput-input MuiInputBase-input MuiSelect-select MuiSelect-standard css-XXXX-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                      id="mui-component-select-search-class"
+                      role="combobox"
+                      tabindex="0"
+                    >
+                      <div
+                        class="MuiListItemText-dense MuiListItemText-root css-XXXX-MuiListItemText-root"
+                      >
+                        <span
+                          class="MuiListItemText-primary MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root"
+                        >
+                          Evidence
+                        </span>
+                        <p
+                          class="MuiListItemText-secondary MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root option-select__option-description"
+                        />
+                      </div>
+                    </div>
+                    <input
+                      aria-hidden="true"
+                      aria-invalid="false"
+                      class="MuiSelect-nativeInput css-XXXX-MuiSelect-nativeInput"
+                      id="option-select-search-class"
+                      name="search-class"
+                      tabindex="-1"
+                      value="Evidence"
+                    />
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSelect-icon MuiSelect-iconStandard MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
+                      data-testid="FilterListIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
+                      />
+                    </svg>
+                  </div>
+                  <p
+                    class="MuiFormHelperText-filled MuiFormHelperText-root MuiFormHelperText-sizeMedium css-XXXX-MuiFormHelperText-root"
+                  />
+                </div>
+                <div
+                  class="MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon MuiAutocomplete-root css-XXXX-MuiAutocomplete-root record-autocomplete"
+                >
+                  <div
+                    class="MuiFormControl-fullWidth MuiFormControl-root MuiTextField-root css-XXXX-MuiFormControl-root-MuiTextField-root"
+                  >
+                    <label
+                      class="Mui-required MuiFormLabel-colorPrimary MuiFormLabel-root MuiInputLabel-animated MuiInputLabel-formControl MuiInputLabel-root MuiInputLabel-shrink MuiInputLabel-standard css-XXXX-MuiFormLabel-root-MuiInputLabel-root"
+                      data-shrink="true"
+                      for="_r_XXXX_"
+                      id="_r_XXXX_-label"
+                    >
+                      evidence
+                      <span
+                        aria-hidden="true"
+                        class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-XXXX-MuiFormLabel-asterisk"
+                      >
+                         
+                        *
+                      </span>
+                    </label>
+                    <div
+                      class="MuiAutocomplete-inputRoot MuiInput-root MuiInput-underline MuiInputBase-adornedEnd MuiInputBase-adornedStart MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-fullWidth MuiInputBase-root css-XXXX-MuiInputBase-root-MuiInput-root"
+                    >
+                      <div
+                        class="detail-chip"
+                      >
+                        <div
+                          class="MuiAutocomplete-tag MuiAutocomplete-tagSizeMedium MuiButtonBase-root MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-colorPrimary MuiChip-deletable MuiChip-deletableColorPrimary MuiChip-outlined MuiChip-outlinedPrimary MuiChip-root MuiChip-sizeSmall css-XXXX-MuiButtonBase-root-MuiChip-root detail-chip__outlined detail-chip__root record-autocomplete__chip record-autocomplete__chip--multi"
+                          data-item-index="0"
+                          role="button"
+                          tabindex="-1"
+                        >
+                          <span
+                            class="MuiChip-label MuiChip-labelSmall css-XXXX-MuiChip-label"
+                          >
+                            FDA approves pembrolizumab for adults and child...
+                          </span>
+                          <svg
+                            aria-hidden="true"
+                            class="MuiChip-deleteIcon MuiChip-deleteIconColorPrimary MuiChip-deleteIconOutlinedColorPrimary MuiChip-deleteIconSmall MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                            data-testid="CancelIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+                            />
+                          </svg>
+                        </div>
+                      </div>
+                      <input
+                        aria-autocomplete="list"
+                        aria-expanded="false"
+                        aria-invalid="false"
+                        autocapitalize="none"
+                        autocomplete="off"
+                        class="MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd MuiInputBase-inputAdornedStart css-XXXX-MuiInputBase-input-MuiInput-input"
+                        id="_r_XXXX_"
+                        placeholder=""
+                        required=""
+                        role="combobox"
+                        spellcheck="false"
+                        type="text"
+                        value=""
+                      />
+                      <div
+                        class="MuiAutocomplete-endAdornment css-XXXX-MuiAutocomplete-endAdornment"
+                      >
+                        <button
+                          aria-label="Clear"
+                          class="MuiAutocomplete-clearIndicator MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-clearIndicator"
+                          tabindex="-1"
+                          title="Clear"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                            data-testid="CloseIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                            />
+                          </svg>
+                        </button>
+                        <button
+                          aria-label="Open"
+                          class="MuiAutocomplete-popupIndicator MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                          tabindex="-1"
+                          title="Open"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                            data-testid="SearchIcon"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <p
+                class="MuiFormHelperText-contained MuiFormHelperText-root MuiFormHelperText-sizeMedium css-XXXX-MuiFormHelperText-root"
+              >
+                One or more pieces of evidence (Literature, DB, etc) which support the overall assertion
+              </p>
+            </div>
+          </li>
+          <ul
+            class="MuiList-padding MuiList-root css-XXXX-MuiList-root form-layout__content-subgroup"
+          >
+            <li
+              class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root form-field form-field--link"
+            >
+              <div
+                class="MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon MuiAutocomplete-root css-XXXX-MuiAutocomplete-root record-autocomplete"
+              >
+                <div
+                  class="MuiFormControl-fullWidth MuiFormControl-root MuiTextField-root css-XXXX-MuiFormControl-root-MuiTextField-root"
+                >
+                  <label
+                    class="Mui-required MuiFormLabel-colorPrimary MuiFormLabel-root MuiInputLabel-animated MuiInputLabel-formControl MuiInputLabel-root MuiInputLabel-shrink MuiInputLabel-standard css-XXXX-MuiFormLabel-root-MuiInputLabel-root"
+                    data-shrink="true"
+                    for="_r_XXXX_"
+                    id="_r_XXXX_-label"
+                  >
+                    relevance
+                    <span
+                      aria-hidden="true"
+                      class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-XXXX-MuiFormLabel-asterisk"
+                    >
+                       
+                      *
+                    </span>
+                  </label>
+                  <div
+                    class="MuiAutocomplete-inputRoot MuiInput-root MuiInputBase-adornedEnd MuiInputBase-adornedStart MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-fullWidth MuiInputBase-root css-XXXX-MuiInputBase-root-MuiInput-root"
+                  >
+                    <div
+                      class="detail-chip"
+                    >
+                      <div
+                        class="MuiAutocomplete-tag MuiAutocomplete-tagSizeMedium MuiButtonBase-root MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-colorPrimary MuiChip-deletable MuiChip-deletableColorPrimary MuiChip-outlined MuiChip-outlinedPrimary MuiChip-root MuiChip-sizeSmall css-XXXX-MuiButtonBase-root-MuiChip-root detail-chip__outlined detail-chip__root record-autocomplete__chip record-autocomplete__chip--multi"
+                        data-item-index="0"
+                        role="button"
+                        tabindex="-1"
+                      >
+                        <span
+                          class="MuiChip-label MuiChip-labelSmall css-XXXX-MuiChip-label"
+                        >
+                          sensitivity (#148:34)
+                        </span>
+                        <svg
+                          aria-hidden="true"
+                          class="MuiChip-deleteIcon MuiChip-deleteIconColorPrimary MuiChip-deleteIconOutlinedColorPrimary MuiChip-deleteIconSmall MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                          data-testid="CancelIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                    <input
+                      aria-autocomplete="list"
+                      aria-describedby="_r_XXXX_-helper-text"
+                      aria-expanded="false"
+                      aria-invalid="false"
+                      autocapitalize="none"
+                      autocomplete="off"
+                      class="MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd MuiInputBase-inputAdornedStart css-XXXX-MuiInputBase-input-MuiInput-input"
+                      id="_r_XXXX_"
+                      placeholder=""
+                      required=""
+                      role="combobox"
+                      spellcheck="false"
+                      type="text"
+                      value=""
+                    />
+                    <div
+                      class="MuiAutocomplete-endAdornment css-XXXX-MuiAutocomplete-endAdornment"
+                    >
+                      <button
+                        aria-label="Clear"
+                        class="MuiAutocomplete-clearIndicator MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-clearIndicator"
+                        tabindex="-1"
+                        title="Clear"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                          data-testid="CloseIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                          />
+                        </svg>
+                      </button>
+                      <button
+                        aria-label="Open"
+                        class="MuiAutocomplete-popupIndicator MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                        tabindex="-1"
+                        title="Open"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                          data-testid="SearchIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                  <p
+                    class="Mui-required MuiFormHelperText-root MuiFormHelperText-sizeMedium css-XXXX-MuiFormHelperText-root"
+                    id="_r_XXXX_-helper-text"
+                  >
+                    Adds meaning to a statement and applies to the "subject" element
+                  </p>
+                </div>
+              </div>
+            </li>
+            <li
+              class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root form-field form-field--link"
+            >
+              <div
+                class="MuiFormControl-root css-XXXX-MuiFormControl-root filtered-record-autocomplete"
+              >
+                <div
+                  class="filtered-record-autocomplete__content"
+                >
+                  <div
+                    class="MuiFormControl-root css-XXXX-MuiFormControl-root filtered-record-autocomplete__select-search-class node-form__class-select option-select"
+                  >
+                    <label
+                      class="MuiFormLabel-colorPrimary MuiFormLabel-filled MuiFormLabel-root MuiInputLabel-animated MuiInputLabel-formControl MuiInputLabel-root MuiInputLabel-shrink MuiInputLabel-standard css-XXXX-MuiFormLabel-root-MuiInputLabel-root"
+                      data-shrink="true"
+                      for="option-select-search-class"
+                    >
+                      Filter (subject) Search by Class
+                    </label>
+                    <div
+                      class="MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-root MuiSelect-root css-XXXX-MuiInputBase-root-MuiInput-root"
+                    >
+                      <div
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        aria-labelledby="mui-component-select-search-class"
+                        class="MuiInput-input MuiInputBase-input MuiSelect-select MuiSelect-standard css-XXXX-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                        id="mui-component-select-search-class"
+                        role="combobox"
+                        tabindex="0"
+                      >
+                        <div
+                          class="MuiListItemText-dense MuiListItemText-root css-XXXX-MuiListItemText-root"
+                        >
+                          <span
+                            class="MuiListItemText-primary MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root"
+                          >
+                            Biomarker
+                          </span>
+                          <p
+                            class="MuiListItemText-secondary MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root option-select__option-description"
+                          />
+                        </div>
+                      </div>
+                      <input
+                        aria-hidden="true"
+                        aria-invalid="false"
+                        class="MuiSelect-nativeInput css-XXXX-MuiSelect-nativeInput"
+                        id="option-select-search-class"
+                        name="search-class"
+                        tabindex="-1"
+                        value="Biomarker"
+                      />
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSelect-icon MuiSelect-iconStandard MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
+                        data-testid="FilterListIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M10 18h4v-2h-4zM3 6v2h18V6zm3 7h12v-2H6z"
+                        />
+                      </svg>
+                    </div>
+                    <p
+                      class="MuiFormHelperText-filled MuiFormHelperText-root MuiFormHelperText-sizeMedium css-XXXX-MuiFormHelperText-root"
+                    />
+                  </div>
+                  <div
+                    class="MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon MuiAutocomplete-root css-XXXX-MuiAutocomplete-root record-autocomplete"
+                  >
+                    <div
+                      class="MuiFormControl-fullWidth MuiFormControl-root MuiTextField-root css-XXXX-MuiFormControl-root-MuiTextField-root"
+                    >
+                      <label
+                        class="Mui-required MuiFormLabel-colorPrimary MuiFormLabel-root MuiInputLabel-animated MuiInputLabel-formControl MuiInputLabel-root MuiInputLabel-shrink MuiInputLabel-standard css-XXXX-MuiFormLabel-root-MuiInputLabel-root"
+                        data-shrink="true"
+                        for="_r_XXXX_"
+                        id="_r_XXXX_-label"
+                      >
+                        subject
+                        <span
+                          aria-hidden="true"
+                          class="MuiFormLabel-asterisk MuiInputLabel-asterisk css-XXXX-MuiFormLabel-asterisk"
+                        >
+                           
+                          *
+                        </span>
+                      </label>
+                      <div
+                        class="MuiAutocomplete-inputRoot MuiInput-root MuiInputBase-adornedEnd MuiInputBase-adornedStart MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-fullWidth MuiInputBase-root css-XXXX-MuiInputBase-root-MuiInput-root"
+                      >
+                        <div
+                          class="detail-chip"
+                        >
+                          <div
+                            class="MuiAutocomplete-tag MuiAutocomplete-tagSizeMedium MuiButtonBase-root MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-colorPrimary MuiChip-deletable MuiChip-deletableColorPrimary MuiChip-outlined MuiChip-outlinedPrimary MuiChip-root MuiChip-sizeSmall css-XXXX-MuiButtonBase-root-MuiChip-root detail-chip__outlined detail-chip__root record-autocomplete__chip record-autocomplete__chip--multi"
+                            data-item-index="0"
+                            role="button"
+                            tabindex="-1"
+                          >
+                            <span
+                              class="MuiChip-label MuiChip-labelSmall css-XXXX-MuiChip-label"
+                            >
+                              pembrolizumab [DB09037] (#122:30774)
+                            </span>
+                            <svg
+                              aria-hidden="true"
+                              class="MuiChip-deleteIcon MuiChip-deleteIconColorPrimary MuiChip-deleteIconOutlinedColorPrimary MuiChip-deleteIconSmall MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                              data-testid="CancelIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+                              />
+                            </svg>
+                          </div>
+                        </div>
+                        <input
+                          aria-autocomplete="list"
+                          aria-expanded="false"
+                          aria-invalid="false"
+                          autocapitalize="none"
+                          autocomplete="off"
+                          class="MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd MuiInputBase-inputAdornedStart css-XXXX-MuiInputBase-input-MuiInput-input"
+                          id="_r_XXXX_"
+                          placeholder=""
+                          required=""
+                          role="combobox"
+                          spellcheck="false"
+                          type="text"
+                          value=""
+                        />
+                        <div
+                          class="MuiAutocomplete-endAdornment css-XXXX-MuiAutocomplete-endAdornment"
+                        >
+                          <button
+                            aria-label="Clear"
+                            class="MuiAutocomplete-clearIndicator MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-clearIndicator"
+                            tabindex="-1"
+                            title="Clear"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                              data-testid="CloseIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                              />
+                            </svg>
+                          </button>
+                          <button
+                            aria-label="Open"
+                            class="MuiAutocomplete-popupIndicator MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                            tabindex="-1"
+                            title="Open"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                              data-testid="SearchIcon"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                              />
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <p
+                  class="MuiFormHelperText-contained MuiFormHelperText-root MuiFormHelperText-sizeMedium css-XXXX-MuiFormHelperText-root"
+                >
+                  The subject of the statement. For example in a therapeutic efficacy statement this would be a drug
+                </p>
+              </div>
+            </li>
+          </ul>
+          <li
+            class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root form-field form-field--string"
+          >
+            <div
+              class="MuiFormControl-root MuiTextField-root css-XXXX-MuiFormControl-root-MuiTextField-root text-field"
+            >
+              <label
+                class="MuiFormLabel-colorPrimary MuiFormLabel-root MuiInputLabel-animated MuiInputLabel-formControl MuiInputLabel-root MuiInputLabel-standard css-XXXX-MuiFormLabel-root-MuiInputLabel-root"
+                data-shrink="false"
+                for="_r_XXXX_"
+                id="_r_XXXX_-label"
+              >
+                description
+              </label>
+              <div
+                class="MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-multiline MuiInputBase-root css-XXXX-MuiInputBase-root-MuiInput-root"
+              >
+                <textarea
+                  aria-describedby="_r_XXXX_-helper-text"
+                  aria-invalid="false"
+                  class="MuiInput-input MuiInputBase-input MuiInputBase-inputMultiline css-XXXX-MuiInputBase-input-MuiInput-input"
+                  data-testid="description"
+                  id="_r_XXXX_"
+                  name="description"
+                />
+                <textarea
+                  aria-hidden="true"
+                  class="MuiInput-input MuiInputBase-input MuiInputBase-inputMultiline css-XXXX-MuiInputBase-input-MuiInput-input"
+                  readonly=""
+                  tabindex="-1"
+                />
+              </div>
+              <p
+                class="MuiFormHelperText-root MuiFormHelperText-sizeMedium css-XXXX-MuiFormHelperText-root"
+                id="_r_XXXX_-helper-text"
+              >
+                <span
+                  aria-hidden="true"
+                  class="notranslate"
+                >
+                  ​
+                </span>
+              </p>
+            </div>
+          </li>
+          <li
+            class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root form-field form-field--linkset"
+          >
+            <div
+              class="MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon MuiAutocomplete-root css-XXXX-MuiAutocomplete-root record-autocomplete"
+            >
+              <div
+                class="MuiFormControl-fullWidth MuiFormControl-root MuiTextField-root css-XXXX-MuiFormControl-root-MuiTextField-root"
+              >
+                <label
+                  class="MuiFormLabel-colorPrimary MuiFormLabel-root MuiInputLabel-animated MuiInputLabel-formControl MuiInputLabel-root MuiInputLabel-shrink MuiInputLabel-standard css-XXXX-MuiFormLabel-root-MuiInputLabel-root"
+                  data-shrink="true"
+                  for="_r_XXXX_"
+                  id="_r_XXXX_-label"
+                >
+                  evidenceLevel
+                </label>
+                <div
+                  class="MuiAutocomplete-inputRoot MuiInput-root MuiInput-underline MuiInputBase-adornedEnd MuiInputBase-adornedStart MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-fullWidth MuiInputBase-root css-XXXX-MuiInputBase-root-MuiInput-root"
+                >
+                  <div
+                    class="detail-chip"
+                  >
+                    <div
+                      class="MuiAutocomplete-tag MuiAutocomplete-tagSizeMedium MuiButtonBase-root MuiChip-clickable MuiChip-clickableColorPrimary MuiChip-colorPrimary MuiChip-deletable MuiChip-deletableColorPrimary MuiChip-outlined MuiChip-outlinedPrimary MuiChip-root MuiChip-sizeSmall css-XXXX-MuiButtonBase-root-MuiChip-root detail-chip__outlined detail-chip__root record-autocomplete__chip record-autocomplete__chip--multi"
+                      data-item-index="0"
+                      role="button"
+                      tabindex="-1"
+                    >
+                      <span
+                        class="MuiChip-label MuiChip-labelSmall css-XXXX-MuiChip-label"
+                      >
+                        IPR-A (#108:30)
+                      </span>
+                      <svg
+                        aria-hidden="true"
+                        class="MuiChip-deleteIcon MuiChip-deleteIconColorPrimary MuiChip-deleteIconOutlinedColorPrimary MuiChip-deleteIconSmall MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                        data-testid="CancelIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <input
+                    aria-autocomplete="list"
+                    aria-describedby="_r_XXXX_-helper-text"
+                    aria-expanded="false"
+                    aria-invalid="false"
+                    autocapitalize="none"
+                    autocomplete="off"
+                    class="MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd MuiInputBase-inputAdornedStart css-XXXX-MuiInputBase-input-MuiInput-input"
+                    id="_r_XXXX_"
+                    placeholder=""
+                    role="combobox"
+                    spellcheck="false"
+                    type="text"
+                    value=""
+                  />
+                  <div
+                    class="MuiAutocomplete-endAdornment css-XXXX-MuiAutocomplete-endAdornment"
+                  >
+                    <button
+                      aria-label="Clear"
+                      class="MuiAutocomplete-clearIndicator MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-clearIndicator"
+                      tabindex="-1"
+                      title="Clear"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                        data-testid="CloseIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                        />
+                      </svg>
+                    </button>
+                    <button
+                      aria-label="Open"
+                      class="MuiAutocomplete-popupIndicator MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                      tabindex="-1"
+                      title="Open"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                        data-testid="SearchIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <p
+                  class="MuiFormHelperText-root MuiFormHelperText-sizeMedium css-XXXX-MuiFormHelperText-root"
+                  id="_r_XXXX_-helper-text"
+                >
+                  A summarization of the supporting evidence for this statment as a category
+                </p>
+              </div>
+            </div>
+          </li>
+          <ul
+            class="MuiList-padding MuiList-root css-XXXX-MuiList-root form-layout__content-subgroup"
+          >
+            <li
+              class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root form-field form-field--string"
+            >
+              <div
+                class="MuiFormControl-root css-XXXX-MuiFormControl-root option-select"
+              >
+                <label
+                  class="MuiFormLabel-colorPrimary MuiFormLabel-filled MuiFormLabel-root MuiInputLabel-animated MuiInputLabel-formControl MuiInputLabel-root MuiInputLabel-shrink MuiInputLabel-standard css-XXXX-MuiFormLabel-root-MuiInputLabel-root"
+                  data-shrink="true"
+                  for="option-select-reviewStatus"
+                >
+                  reviewStatus
+                </label>
+                <div
+                  class="MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-root MuiSelect-root css-XXXX-MuiInputBase-root-MuiInput-root"
+                >
+                  <div
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    aria-labelledby="mui-component-select-reviewStatus"
+                    class="MuiInput-input MuiInputBase-input MuiSelect-select MuiSelect-standard css-XXXX-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                    id="mui-component-select-reviewStatus"
+                    role="combobox"
+                    tabindex="0"
+                  >
+                    <div
+                      class="MuiListItemText-dense MuiListItemText-root css-XXXX-MuiListItemText-root"
+                    >
+                      <span
+                        class="MuiListItemText-primary MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root"
+                      >
+                        passed
+                      </span>
+                      <p
+                        class="MuiListItemText-secondary MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root option-select__option-description"
+                      />
+                    </div>
+                  </div>
+                  <input
+                    aria-hidden="true"
+                    aria-invalid="false"
+                    class="MuiSelect-nativeInput css-XXXX-MuiSelect-nativeInput"
+                    id="option-select-reviewStatus"
+                    name="reviewStatus"
+                    tabindex="-1"
+                    value="passed"
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSelect-icon MuiSelect-iconStandard MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root-MuiNativeSelect-root-MuiSelect-icon"
+                    data-testid="ArrowDropDownIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="m7 10 5 5 5-5z"
+                    />
+                  </svg>
+                </div>
+                <p
+                  class="MuiFormHelperText-filled MuiFormHelperText-root MuiFormHelperText-sizeMedium css-XXXX-MuiFormHelperText-root"
+                >
+                  The review status of the overall statement. The amalgemated status of all (or no) reviews (ex. pending)
+                </p>
+              </div>
+            </li>
+            <li
+              class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root form-field form-field--embeddedlist"
+            >
+              <div
+                class="embedded-list-table"
+              >
+                <h6
+                  class="MuiTypography-alignCenter MuiTypography-root MuiTypography-subtitle1 css-XXXX-MuiTypography-root"
+                >
+                  Reviews
+                </h6>
+                <table
+                  class="MuiTable-root css-XXXX-MuiTable-root embedded-list-table__table"
+                >
+                  <thead
+                    class="MuiTableHead-root css-XXXX-MuiTableHead-root embedded-list-table__table-header"
+                  >
+                    <tr
+                      class="MuiTableRow-head MuiTableRow-root css-XXXX-MuiTableRow-root"
+                    >
+                      <th
+                        class="MuiTableCell-head MuiTableCell-root MuiTableCell-sizeSmall css-XXXX-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Review Status
+                      </th>
+                      <th
+                        class="MuiTableCell-head MuiTableCell-root MuiTableCell-sizeSmall css-XXXX-MuiTableCell-root"
+                        scope="col"
+                      >
+                        Reviewer
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    class="MuiTableBody-root css-XXXX-MuiTableBody-root"
+                  >
+                    <tr
+                      class="MuiTableRow-root css-XXXX-MuiTableRow-root"
+                    >
+                      <td
+                        class="MuiTableCell-body MuiTableCell-root MuiTableCell-sizeSmall css-XXXX-MuiTableCell-root"
+                      >
+                        initial
+                      </td>
+                      <td
+                        class="MuiTableCell-body MuiTableCell-root MuiTableCell-sizeSmall css-XXXX-MuiTableCell-root"
+                      >
+                        <div
+                          class="detail-chip"
+                        >
+                          <div
+                            class="MuiButtonBase-root MuiChip-clickable MuiChip-clickableColorSecondary MuiChip-colorSecondary MuiChip-outlined MuiChip-outlinedSecondary MuiChip-root MuiChip-sizeSmall css-XXXX-MuiButtonBase-root-MuiChip-root detail-chip__outlined detail-chip__root"
+                            role="button"
+                            tabindex="0"
+                          >
+                            <span
+                              class="MuiChip-label MuiChip-labelSmall css-XXXX-MuiChip-label"
+                            >
+                              undefined (undefined)
+                            </span>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </li>
+          </ul>
+          <ul
+            class="MuiList-padding MuiList-root css-XXXX-MuiList-root form-layout__content-subgroup"
+          >
+            <li
+              class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root form-field form-field--link"
+            >
+              <div
+                class="MuiAutocomplete-hasPopupIcon MuiAutocomplete-root css-XXXX-MuiAutocomplete-root record-autocomplete"
+              >
+                <div
+                  class="MuiFormControl-fullWidth MuiFormControl-root MuiTextField-root css-XXXX-MuiFormControl-root-MuiTextField-root"
+                >
+                  <label
+                    class="MuiFormLabel-colorPrimary MuiFormLabel-root MuiInputLabel-animated MuiInputLabel-formControl MuiInputLabel-root MuiInputLabel-shrink MuiInputLabel-standard css-XXXX-MuiFormLabel-root-MuiInputLabel-root"
+                    data-shrink="true"
+                    for="_r_XXXX_"
+                    id="_r_XXXX_-label"
+                  >
+                    source
+                  </label>
+                  <div
+                    class="MuiAutocomplete-inputRoot MuiInput-root MuiInput-underline MuiInputBase-adornedEnd MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-fullWidth MuiInputBase-root css-XXXX-MuiInputBase-root-MuiInput-root"
+                  >
+                    <input
+                      aria-autocomplete="list"
+                      aria-describedby="_r_XXXX_-helper-text"
+                      aria-expanded="false"
+                      aria-invalid="false"
+                      autocapitalize="none"
+                      autocomplete="off"
+                      class="MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInput-input MuiInputBase-input MuiInputBase-inputAdornedEnd css-XXXX-MuiInputBase-input-MuiInput-input"
+                      id="_r_XXXX_"
+                      placeholder="Search Records by Name or ID"
+                      role="combobox"
+                      spellcheck="false"
+                      type="text"
+                      value=""
+                    />
+                    <div
+                      class="MuiAutocomplete-endAdornment css-XXXX-MuiAutocomplete-endAdornment"
+                    >
+                      <button
+                        aria-label="Open"
+                        class="MuiAutocomplete-popupIndicator MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-XXXX-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                        tabindex="-1"
+                        title="Open"
+                        type="button"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+                          data-testid="SearchIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                  <p
+                    class="MuiFormHelperText-root MuiFormHelperText-sizeMedium css-XXXX-MuiFormHelperText-root"
+                    id="_r_XXXX_-helper-text"
+                  >
+                    If the statement is imported from an external source, it is linked here
+                  </p>
+                </div>
+              </div>
+            </li>
+            <li
+              class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root form-field form-field--string"
+            >
+              <div
+                class="MuiFormControl-root MuiTextField-root css-XXXX-MuiFormControl-root-MuiTextField-root text-field"
+              >
+                <label
+                  class="MuiFormLabel-colorPrimary MuiFormLabel-root MuiInputLabel-animated MuiInputLabel-formControl MuiInputLabel-root MuiInputLabel-standard css-XXXX-MuiFormLabel-root-MuiInputLabel-root"
+                  data-shrink="false"
+                  for="_r_XXXX_"
+                  id="_r_XXXX_-label"
+                >
+                  sourceId
+                </label>
+                <div
+                  class="MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-multiline MuiInputBase-root css-XXXX-MuiInputBase-root-MuiInput-root"
+                >
+                  <textarea
+                    aria-describedby="_r_XXXX_-helper-text"
+                    aria-invalid="false"
+                    class="MuiInput-input MuiInputBase-input MuiInputBase-inputMultiline css-XXXX-MuiInputBase-input-MuiInput-input"
+                    data-testid="sourceId"
+                    id="_r_XXXX_"
+                    name="sourceId"
+                  />
+                  <textarea
+                    aria-hidden="true"
+                    class="MuiInput-input MuiInputBase-input MuiInputBase-inputMultiline css-XXXX-MuiInputBase-input-MuiInput-input"
+                    readonly=""
+                    tabindex="-1"
+                  />
+                </div>
+                <p
+                  class="MuiFormHelperText-root MuiFormHelperText-sizeMedium css-XXXX-MuiFormHelperText-root"
+                  id="_r_XXXX_-helper-text"
+                >
+                  If the statement is imported from an external source, this is used to track the statement. This is not used for manually entered statements
+                </p>
+              </div>
+            </li>
+          </ul>
+        </ul>
+        <li
+          class="MuiListItem-dense MuiListItem-gutters MuiListItem-padding MuiListItem-root css-XXXX-MuiListItem-root"
+        >
+          <div
+            class="MuiListItemText-dense MuiListItemText-root css-XXXX-MuiListItemText-root"
+          >
+            <span
+              class="MuiListItemText-primary MuiTypography-body2 MuiTypography-root css-XXXX-MuiTypography-root"
+            >
+              Expand to see all optional fields
+            </span>
+          </div>
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-fontSizeSmall MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+            data-testid="ExpandMoreIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+            />
+          </svg>
+        </li>
+      </div>
+      <div
+        class="MuiAlert-colorError MuiAlert-root MuiAlert-standard MuiAlert-standardError MuiPaper-elevation MuiPaper-elevation0 MuiPaper-root MuiPaper-rounded css-XXXX-MuiPaper-root-MuiAlert-root"
+        role="alert"
+      >
+        <div
+          class="MuiAlert-icon css-XXXX-MuiAlert-icon"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-fontSizeInherit MuiSvgIcon-root css-XXXX-MuiSvgIcon-root"
+            data-testid="ErrorOutlineIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+            />
+          </svg>
+        </div>
+        <div
+          class="MuiAlert-message css-XXXX-MuiAlert-message"
+        >
+          An error occurred while deleting record.
+          Insufficient permissions to delete record.
+          Report this error in a
+          <a
+            href="https://www.bcgsc.ca/jira/projects/KBDEV"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Ticket/Issue
+          </a>
+           ticket or email us at 
+          <a
+            href="mailto:graphkb@bcgsc.ca?subject=AuthorizationError%3A%20Insufficient%20permissions%20to%20delete%20record.&body=Error%20Details%20(Please%20include%20in%20error%20reports)%0Aversion%3A%204.4.1%0Aerror%20name%3A%20AuthorizationError%0Aerror%20text%3A%20Insufficient%20permissions%20to%20delete%20record."
+          >
+            graphkb@bcgsc.ca
+          </a>
+          .
+        </div>
+      </div>
+      <div
+        class="statement-form__action-buttons"
+      >
+        <div
+          class="action-button"
+        >
+          <button
+            class="MuiButton-colorError MuiButton-outlined MuiButton-outlinedError MuiButton-outlinedSizeLarge MuiButton-root MuiButton-sizeLarge MuiButtonBase-root action-button__button css-XXXX-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            DELETE RECORD
+            <span
+              class="MuiTouchRipple-root css-XXXX-MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+        <div
+          class="action-button"
+        >
+          <button
+            class="MuiButton-colorPrimary MuiButton-contained MuiButton-containedPrimary MuiButton-containedSizeLarge MuiButton-root MuiButton-sizeLarge MuiButtonBase-root action-button__button css-XXXX-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            SUBMIT CHANGES
+          </button>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/src/views/RecordView/__snapshots__/index.stories.tsx.snap
+++ b/src/views/RecordView/__snapshots__/index.stories.tsx.snap
@@ -2519,6 +2519,59 @@ exports[`EditStatement snapshot 1`] = `
 </div>
 `;
 
+exports[`EditStatementErrorDeleting snapshot 1`] = `
+<div>
+  <div
+  >
+    <div
+      class="error-wrapper"
+    >
+      <h2
+        class="MuiTypography-h2 MuiTypography-root css-XXXX-MuiTypography-root"
+      >
+        AuthorizationError
+      </h2>
+      <h3
+        class="MuiTypography-h3 MuiTypography-root css-XXXX-MuiTypography-root"
+      >
+        Insufficient permissions to delete record.
+      </h3>
+      <p
+        class="MuiTypography-body1 MuiTypography-paragraph MuiTypography-root css-XXXX-MuiTypography-root"
+      >
+        Report this error in a
+        <a
+          href="https://www.bcgsc.ca/jira/projects/KBDEV"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Ticket/Issue
+        </a>
+         ticket or email us at 
+        <a
+          href="mailto:graphkb@bcgsc.ca?subject=AuthorizationError%3A%20Insufficient%20permissions%20to%20delete%20record.&body=Error%20Details%20(Please%20include%20in%20error%20reports)%0Aversion%3A%204.4.1%0Aerror%20name%3A%20AuthorizationError%0Aerror%20text%3A%20Insufficient%20permissions%20to%20delete%20record."
+        >
+          graphkb@bcgsc.ca
+        </a>
+        .
+      </p>
+      <a
+        data-discover="true"
+        href="/"
+      >
+        <button
+          class="MuiButton-colorPrimary MuiButton-contained MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-root MuiButton-sizeSmall MuiButtonBase-root css-XXXX-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          Home
+        </button>
+      </a>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`ViewAliasOf snapshot 1`] = `
 <div>
   <div
@@ -3030,6 +3083,59 @@ exports[`ViewAliasOf snapshot 1`] = `
         <div />
         <div />
       </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ViewAliasOfNotFound snapshot 1`] = `
+<div>
+  <div
+  >
+    <div
+      class="error-wrapper"
+    >
+      <h2
+        class="MuiTypography-h2 MuiTypography-root css-XXXX-MuiTypography-root"
+      >
+        APIConnectionFailureError
+      </h2>
+      <h3
+        class="MuiTypography-h3 MuiTypography-root css-XXXX-MuiTypography-root"
+      >
+        query expected 1 records but only found 0
+      </h3>
+      <p
+        class="MuiTypography-body1 MuiTypography-paragraph MuiTypography-root css-XXXX-MuiTypography-root"
+      >
+        Report this error in a
+        <a
+          href="https://www.bcgsc.ca/jira/projects/KBDEV"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Ticket/Issue
+        </a>
+         ticket or email us at 
+        <a
+          href="mailto:graphkb@bcgsc.ca?subject=APIConnectionFailureError%3A%20query%20expected%201%20records%20but%20only%20found%200&body=Error%20Details%20(Please%20include%20in%20error%20reports)%0Aversion%3A%204.4.1%0Aerror%20name%3A%20APIConnectionFailureError%0Aerror%20text%3A%20query%20expected%201%20records%20but%20only%20found%200"
+        >
+          graphkb@bcgsc.ca
+        </a>
+        .
+      </p>
+      <a
+        data-discover="true"
+        href="/"
+      >
+        <button
+          class="MuiButton-colorPrimary MuiButton-contained MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-root MuiButton-sizeSmall MuiButtonBase-root css-XXXX-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          Home
+        </button>
+      </a>
     </div>
   </div>
 </div>
@@ -6877,6 +6983,59 @@ exports[`ViewStatement snapshot 1`] = `
         <div />
         <div />
       </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ViewStatementNotFound snapshot 1`] = `
+<div>
+  <div
+  >
+    <div
+      class="error-wrapper"
+    >
+      <h2
+        class="MuiTypography-h2 MuiTypography-root css-XXXX-MuiTypography-root"
+      >
+        APIConnectionFailureError
+      </h2>
+      <h3
+        class="MuiTypography-h3 MuiTypography-root css-XXXX-MuiTypography-root"
+      >
+        query expected 1 records but only found 0
+      </h3>
+      <p
+        class="MuiTypography-body1 MuiTypography-paragraph MuiTypography-root css-XXXX-MuiTypography-root"
+      >
+        Report this error in a
+        <a
+          href="https://www.bcgsc.ca/jira/projects/KBDEV"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Ticket/Issue
+        </a>
+         ticket or email us at 
+        <a
+          href="mailto:graphkb@bcgsc.ca?subject=APIConnectionFailureError%3A%20query%20expected%201%20records%20but%20only%20found%200&body=Error%20Details%20(Please%20include%20in%20error%20reports)%0Aversion%3A%204.4.1%0Aerror%20name%3A%20APIConnectionFailureError%0Aerror%20text%3A%20query%20expected%201%20records%20but%20only%20found%200"
+        >
+          graphkb@bcgsc.ca
+        </a>
+        .
+      </p>
+      <a
+        data-discover="true"
+        href="/"
+      >
+        <button
+          class="MuiButton-colorPrimary MuiButton-contained MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-root MuiButton-sizeSmall MuiButtonBase-root css-XXXX-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          Home
+        </button>
+      </a>
     </div>
   </div>
 </div>

--- a/src/views/RecordView/index.stories.tsx
+++ b/src/views/RecordView/index.stories.tsx
@@ -1,5 +1,5 @@
 import { HttpResponse } from 'msw';
-import { expect, screen, waitForElementToBeRemoved } from 'storybook/test';
+import { expect, screen } from 'storybook/test';
 
 import preview, {
   hasFinishedLoading,
@@ -301,8 +301,6 @@ export const EditStatementErrorDeleting = ViewStatement.extend({
     await hasFinishedLoading({ canvas, step });
     await userEvent.click(await canvas.findByText(/delete record/i));
     await userEvent.click(await screen.findByText(/confirm/i));
-    const snackbar = await canvas.findByText(/Error \(AuthorizationError\) in deleting the record \(#153:14338\)/);
     await canvas.findByText(/Insufficient permissions to delete record./, { exact: false });
-    await waitForElementToBeRemoved(snackbar, { timeout: 10000 });
   },
 });

--- a/src/views/RecordView/index.stories.tsx
+++ b/src/views/RecordView/index.stories.tsx
@@ -1,5 +1,5 @@
 import { HttpResponse } from 'msw';
-import { expect } from 'storybook/test';
+import { expect, screen, waitForElementToBeRemoved } from 'storybook/test';
 
 import preview, {
   hasFinishedLoading,
@@ -58,6 +58,21 @@ export const ViewAliasOfOptionalFieldsExpanded = ViewAliasOf.extend({
     await hasFinishedLoading({ canvas, step });
     await userEvent.click(await canvas.findByText('Expand to see all optional fields'));
     await expect(canvas.findByText('@rid')).resolves.toBeInTheDocument();
+  },
+});
+
+export const ViewAliasOfNotFound = meta.story({
+  args: {
+    path: '/view/AliasOf/65:69073',
+    auth: { hasWriteAccess: true },
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        http.gkb.query(() => []),
+        http.gkb.get('/api/aliasof/:rid', () => HttpResponse.json({ message: 'query expected 1 records but only found 0', name: 'NoRecordFoundError' }, { status: 404 })),
+      ],
+    },
   },
 });
 
@@ -245,6 +260,21 @@ export const ViewStatement = meta.story({
   },
 });
 
+export const ViewStatementNotFound = meta.story({
+  args: {
+    path: '/view/Statement/157:106045',
+    auth: { hasWriteAccess: true },
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        http.gkb.query(() => []),
+        http.gkb.get('/api/statements/:rid', () => HttpResponse.json({ message: 'query expected 1 records but only found 0', name: 'NoRecordFoundError' }, { status: 404 })),
+      ],
+    },
+  },
+});
+
 export const ViewStatementOptionalFieldsExpanded = ViewStatement.extend({
   play: async ({ canvas, userEvent, step }) => {
     await hasFinishedLoading({ canvas, step });
@@ -255,4 +285,24 @@ export const ViewStatementOptionalFieldsExpanded = ViewStatement.extend({
 
 export const EditStatement = ViewStatement.extend({
   args: { path: '/edit/Statement/157:106045' },
+});
+
+export const EditStatementErrorDeleting = ViewStatement.extend({
+  args: { path: '/edit/Statement/157:106045' },
+  parameters: {
+    msw: {
+      handlers: [
+        ...ViewStatement.input.parameters.msw.handlers,
+        http.gkb.delete('/api/statements/:rid', () => HttpResponse.json({ message: 'Insufficient permissions to delete record.' }, { status: 403 })),
+      ],
+    },
+  },
+  play: async ({ canvas, userEvent, step }) => {
+    await hasFinishedLoading({ canvas, step });
+    await userEvent.click(await canvas.findByText(/delete record/i));
+    await userEvent.click(await screen.findByText(/confirm/i));
+    const snackbar = await canvas.findByText(/Error \(AuthorizationError\) in deleting the record \(#153:14338\)/);
+    await canvas.findByText(/Insufficient permissions to delete record./, { exact: false });
+    await waitForElementToBeRemoved(snackbar, { timeout: 10000 });
+  },
 });

--- a/src/views/RecordView/index.tsx
+++ b/src/views/RecordView/index.tsx
@@ -13,8 +13,7 @@ import React, {
 } from 'react';
 import { useQuery } from 'react-query';
 import {
-  NavigateOptions,
-  useLocation, useNavigate, useParams, useSearchParams,
+  useLocation, useNavigate, useParams,
 } from 'react-router';
 
 import RecordForm from '@/components/RecordForm';
@@ -26,7 +25,6 @@ import {
 import VariantForm from '@/components/VariantForm';
 import api from '@/services/api';
 import schema from '@/services/schema';
-import util from '@/services/util';
 
 window.Buffer = window.Buffer || Buffer;
 
@@ -81,22 +79,12 @@ const RecordView = ({
   const modelNameParam = modelNameParamProp ?? modelNameParams;
 
   const { pathname: path } = useLocation();
-  const [searchParams] = useSearchParams();
   const [modelName, setModelName] = useState(modelNameParam || '');
 
   useEffect(() => {
     if (path) {
-      try {
-        const name = getModelFromName(path, modelNameParam, variant);
-        setModelName(name as ModelNamesType);
-      } catch (err) {
-        if (err instanceof Error) {
-          const error: NavigateOptions = { state: { error: { name: err.name, message: err.toString() } } };
-          navigate('/error', error);
-        } else {
-          console.error(err);
-        }
-      }
+      const name = getModelFromName(path, modelNameParam, variant);
+      setModelName(name as ModelNamesType);
     }
   }, [path, modelNameParam, variant, navigate]);
 
@@ -118,37 +106,18 @@ const RecordView = ({
     }
   }, [navigate, variant]);
 
-  /**
-   * Handles the redirect if an error occurs in the child component
-   */
-  const handleError = useCallback(({ error = {} }: { error?: { name?: string; message?: string } }) => {
-    const { name } = error;
-    const massagedMsg = util.massageRecordExistsError(error);
-    util.handleErrorSaveLocation(
-      { name, message: massagedMsg },
-      { navigate, pathname: path, search: searchParams.toString() },
-    );
-  }, [navigate, path, searchParams]);
-
   const model = useMemo(() => schemaDefn.get(modelName || 'V'), [modelName]);
 
-  const { data: recordContent, error } = useQuery({
+  const { data: recordContent } = useQuery({
     queryKey: tuple(`${model?.routeName}/${rid?.replace(/^#/, '')}?neighbors=1`, { forceListReturn: true, variant }),
     queryFn: async ({ queryKey: [route, options] }) => {
-      if (!model) {
-        handleError({ error: { name: 'ModelNotFound', message: `Unable to find model for ${modelName}` } });
-        return undefined;
-      }
       const result = await api.get(route, options);
 
-      if (result && result.length) {
-        return { ...result[0] };
-      }
-      handleError({ error: { name: 'RecordNotFound', message: `Unable to retrieve record details for ${model.routeName}/${rid}` } });
-      return undefined;
+      return { ...result[0] };
     },
     enabled: Boolean(variant !== FORM_VARIANT.NEW && variant !== FORM_VARIANT.SEARCH && rid),
     refetchOnMount: 'always',
+    throwOnError: true,
   });
 
   useEffect(() => {
@@ -156,12 +125,6 @@ const RecordView = ({
       setModelName(recordContent['@class']);
     }
   }, [recordContent]);
-
-  useEffect(() => {
-    if (error) {
-      handleError({ error });
-    }
-  }, [error, handleError]);
 
   // redirect when the user clicks the top right button
   const handleToggleState = useCallback((newState: FORM_VARIANT | 'graph') => {
@@ -188,7 +151,6 @@ const RecordView = ({
       <div className="edit-variant-view">
         <VariantForm
           formVariant={variant}
-          onError={handleError}
           onSubmit={handleSubmit}
           value={recordContent}
         />
@@ -198,7 +160,6 @@ const RecordView = ({
   if (modelName.toLowerCase() === 'statement') {
     return (
       <StatementForm
-        onError={handleError}
         onSubmit={handleSubmit}
         onToggleState={handleToggleState}
         title={DEFAULT_TITLES[variant].replace(':modelName', 'Statement')}
@@ -210,7 +171,6 @@ const RecordView = ({
   return (
     <RecordForm
       modelName={modelName}
-      onError={handleError}
       onSubmit={handleSubmit}
       onToggleState={handleToggleState}
       title={DEFAULT_TITLES[variant].replace(':modelName', modelName)}

--- a/src/views/RecordView/index.tsx
+++ b/src/views/RecordView/index.tsx
@@ -5,6 +5,7 @@ import {
   CircularProgress,
 } from '@mui/material';
 import { Buffer } from 'buffer';
+import { useSnackbar } from 'notistack';
 import * as qs from 'qs';
 import React, {
   useCallback, useEffect, useMemo,
@@ -70,6 +71,7 @@ const RecordView = ({
   variant: FORM_VARIANT;
 }) => {
   const navigate = useNavigate();
+  const snackbar = useSnackbar();
   const {
     rid,
     modelName: modelNameParams,
@@ -166,12 +168,12 @@ const RecordView = ({
     // Will give newState as null if user clicks same state (view/edit/graph)
     if (!newState) { return; }
     if (newState === 'graph') {
-      navigateToGraph([recordContent['@rid']], navigate, handleError);
+      navigateToGraph([recordContent['@rid']], navigate, snackbar);
     } else {
       const newPath = `/${newState}/${model.name}/${rid}`;
       navigate(newPath);
     }
-  }, [handleError, navigate, model.name, recordContent, rid]);
+  }, [snackbar, navigate, model.name, recordContent, rid]);
 
   if (!modelName || (variant !== FORM_VARIANT.NEW && (!recordContent || !recordContent['@rid']))) {
     // wait for the model to be set for new Records

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -83,6 +83,7 @@ export default defineConfig(({ mode }) => {
             storybookTest({
               configDir: path.join(__dirname, '.storybook'),
               storybookScript: 'npm run storybook --no-open',
+              tags: { exclude: ['flaky']}
             }),
           ],
           test: {


### PR DESCRIPTION
see ticket for example of new error display

this changes to no longer navigate to an /error page when an error occurs. instead, errors from mutations are shown inline, errors loading a page use the error boundary (so the url doesn't change but it looks the same as the previous /error page did), and other errors use a snackbar